### PR TITLE
Fix nginx configuration for openstack-web

### DIFF
--- a/classes/system/nginx/server/proxy/openstack_web.yml
+++ b/classes/system/nginx/server/proxy/openstack_web.yml
@@ -1,4 +1,7 @@
 parameters:
+  _param:
+    nginx_proxy_openstack_web_host: ${_param:cluster_public_host}
+    nginx_proxy_openstack_web_proxy_host: ${_param:cluster_vip_address}
   nginx:
     server:
       enabled: true
@@ -8,12 +11,12 @@ parameters:
           type: nginx_proxy
           name: openstack_web
           proxy:
-            host: localhost
+            host: ${_param:nginx_proxy_openstack_web_proxy_host}
             port: 8078
             protocol: http
             websocket: true
           host:
-            name: ${_param:cluster_public_host}
+            name: ${_param:nginx_proxy_openstack_web_host}
             port: 443
             protocol: https
           ssl:
@@ -26,5 +29,5 @@ parameters:
           type: nginx_redirect
           name: openstack_web_redirect
           host:
-            name: ${_param:cluster_public_host}
+            name: ${_param:nginx_proxy_openstack_web_host}
             port: 80


### PR DESCRIPTION
This commit fixes the nginx configuration for openstack-web (OpenStack Horizon).

This follows up on commit 9f01df8647df61e282a06528184c96d8c8e013a7 which changed the model to deploy Horizon on the controller nodes instead of the config node.