### PR TITLE
Remove unused model file

### DIFF
--- a/classes/system/rabbitmq/server/openstack.yml
+++ b/classes/system/rabbitmq/server/openstack.yml
@@ -1,8 +1,0 @@
-parameters:
-  rabbitmq:
-    server:
-      host:
-        '/openstack':
-          enabled: true
-          user: monitor
-          password: ${_param:rabbitmq_graphite_password}


### PR DESCRIPTION
This commit removes the `system/rabbitmq/server/openstack.yml` class file, which
is not used. The OpenStack-related RabbitMQ configuration is in
`system/openstack/control/mk20_lab.yml`.