### PR TITLE
Add InfluxDB parameters

### DIFF
--- a/classes/system/heka/metric_collector/single.yml
+++ b/classes/system/heka/metric_collector/single.yml
@@ -6,3 +6,11 @@ parameters:
   heka:
     metric_collector:
       enabled: true
+      output:
+        influxdb:
+          engine: influxdb
+          host: ${_param:heka_influxdb_host}
+          port: ${_param:influxdb_port}
+          database: ${_param:influxdb_database}
+          username: ${_param:influxdb_user}
+          password: ${_param:influxdb_password}

--- a/classes/system/openstack/common/mk20_stacklight.yml
+++ b/classes/system/openstack/common/mk20_stacklight.yml
@@ -11,6 +11,7 @@ parameters:
     heka_amqp_host: mon
     heka_amqp_password: workshop
     heka_elasticsearch_host: mon
+    heka_influxdb_host: mon
     opencontrail_version: 3.0
     opencontrail_compute_dns: 8.8.8.8
     opencontrail_stats_password: contrail123
@@ -76,3 +77,7 @@ parameters:
     mongodb_ceilometer_password: cloudlab
     mongodb_admin_password: cloudlab
     mongodb_shared_key: eoTh1AwahlahqueingeejooLughah4tei9feing0eeVaephooDi2li1TaeV1ooth
+    influxdb_port: 8086
+    influxdb_database: lma
+    influxdb_user: lma
+    influxdb_password: lmapass


### PR DESCRIPTION
This declares an InfluxDB output plugin in `heka:metric_collector:output`. This depends on https://github.com/tcpcloud/salt-formula-heka/pull/13, which should be merged first.