### PR TITLE
Fix missing keystone services for components

### DIFF
--- a/classes/system/keystone/server/service/billometer.yml
+++ b/classes/system/keystone/server/service/billometer.yml
@@ -1,0 +1,23 @@
+parameters:
+  keystone:
+    server:
+      service:
+        billometer:
+          type: billing
+          description: Openstack Billing Service
+          user:
+            name: billometer
+            password: ${_param:keystone_billometer_password}
+          bind:
+            public_address: ${_param:billometer_service_host}
+            public_protocol: http
+            public_port: 9753
+            public_path: '/v1'
+            internal_address: ${_param:billometer_service_host}
+            internal_protocol: http
+            internal_port: 9753
+            internal_path: '/v1'
+            admin_address: ${_param:billometer_service_host}
+            admin_protocol: http
+            admin_port: 9753
+            admin_path: '/v1'

--- a/classes/system/keystone/server/service/ceilometer.yml
+++ b/classes/system/keystone/server/service/ceilometer.yml
@@ -1,0 +1,23 @@
+parameters:
+  keystone:
+    server:
+      service:
+        ceilometer:
+          type: metering
+          description: OpenStack Telemetry Service
+          user:
+            name: ceilometer
+            password: ${_param:keystone_ceilometer_password}
+          bind:
+            public_address: ${_param:ceilometer_service_host}
+            public_protocol: http
+            public_port: 8777
+            public_path: '/'
+            internal_address: ${_param:ceilometer_service_host}
+            internal_protocol: http
+            internal_port: 8777
+            internal_path: '/'
+            admin_address: ${_param:ceilometer_service_host}
+            admin_protocol: http
+            admin_port: 8777
+            admin_path: '/'

--- a/classes/system/keystone/server/service/cinder.yml
+++ b/classes/system/keystone/server/service/cinder.yml
@@ -1,0 +1,41 @@
+parameters:
+  keystone:
+    server:
+      service:
+        cinder:
+          type: volume
+          description: OpenStack Volume Service
+          user:
+            name: cinder
+            password: ${_param:keystone_cinder_password}
+          bind:
+            public_address: ${_param:cinder_service_host}
+            public_protocol: http
+            public_port: 8776
+            public_path: '/v1/$(tenant_id)s'
+            internal_address: ${_param:cinder_service_host}
+            internal_protocol: http
+            internal_port: 8776
+            internal_path: '/v1/$(tenant_id)s'
+            admin_address: ${_param:cinder_service_host}
+            admin_protocol: http
+            admin_port: 8776
+            admin_path: '/v1/$(tenant_id)s'
+            public_protocol: http
+        cinderv2:
+          type: volumev2
+          description: OpenStack Volume Service v2.0
+          bind:
+            public_address: ${_param:cinder_service_host}
+            public_protocol: http
+            public_port: 8776
+            public_path: '/v2/$(tenant_id)s'
+            internal_address: ${_param:cinder_service_host}
+            internal_protocol: http
+            internal_port: 8776
+            internal_path: '/v2/$(tenant_id)s'
+            admin_address: ${_param:cinder_service_host}
+            admin_protocol: http
+            admin_port: 8776
+            admin_path: '/v2/$(tenant_id)s'
+            public_protocol: http

--- a/classes/system/keystone/server/service/glance.yml
+++ b/classes/system/keystone/server/service/glance.yml
@@ -1,0 +1,23 @@
+parameters:
+  keystone:
+    server:
+      service:
+        glance:
+          type: image
+          description: OpenStack Image Service
+          user:
+            name: glance
+            password: ${_param:keystone_glance_password}
+          bind:
+            public_address: ${_param:glance_service_host}
+            public_protocol: http
+            public_port: 9292
+            public_path: ''
+            internal_address: ${_param:glance_service_host}
+            internal_port: 9292
+            internal_protocol: http
+            internal_path: ''
+            admin_address: ${_param:glance_service_host}
+            admin_port: 9292
+            admin_protocol: http
+            admin_path: ''

--- a/classes/system/keystone/server/service/heat.yml
+++ b/classes/system/keystone/server/service/heat.yml
@@ -1,0 +1,40 @@
+parameters:
+  keystone:
+    server:
+      service:
+        heat:
+          type: orchestration
+          description: Heat Orchestration API
+          user:
+            name: heat
+            password: ${_param:keystone_heat_password}
+          bind:
+            public_address: ${_param:heat_service_host}
+            public_protocol: http
+            public_port: 8004
+            internal_address: ${_param:heat_service_host}
+            internal_port: 8004
+            admin_address: ${_param:heat_service_host}
+            admin_port: 8004
+            public_protocol: http
+            public_path: '/v1/%(tenant_id)s'
+            internal_protocol: http
+            internal_path: '/v1/%(tenant_id)s'
+            admin_protocol: http
+            admin_path: '/v1/%(tenant_id)s'
+        heat-cfn:
+          type: cloudformation
+          description: AWS CloudFormation API
+          bind:
+            public_address: ${_param:heat_service_host}
+            public_protocol: http
+            public_port: 8000
+            public_path: '/v1'
+            internal_address: ${_param:heat_service_host}
+            internal_protocol: http
+            internal_port: 8000
+            internal_path: '/v1'
+            admin_address: ${_param:heat_service_host}
+            admin_protocol: http
+            admin_port: 8000
+            admin_path: '/v1'

--- a/classes/system/keystone/server/service/keystone.yml
+++ b/classes/system/keystone/server/service/keystone.yml
@@ -1,0 +1,20 @@
+parameters:
+  keystone:
+    server:
+      service:
+        keystone:
+          type: identity
+          description: OpenStack Identity Service
+          bind:
+            public_address: ${_param:keystone_service_host}
+            public_port: 5000
+            public_protocol: http
+            public_path: '/v2.0'
+            internal_address: ${_param:keystone_service_host}
+            internal_port: 5000
+            internal_protocol: http
+            internal_path: '/v2.0'
+            admin_address: ${_param:keystone_service_host}
+            admin_port: 35357
+            admin_protocol: http
+            admin_path: '/v2.0'

--- a/classes/system/keystone/server/service/keystone3.yml
+++ b/classes/system/keystone/server/service/keystone3.yml
@@ -1,0 +1,20 @@
+parameters:
+  keystone:
+    server:
+      service:
+        keystone3:
+          type: identity
+          description: OpenStack Identity Service v3.0
+          bind:
+            public_address: ${_param:keystone_service_host}
+            public_port: 5000
+            public_protocol: http
+            public_path: '/v2.0'
+            internal_address: ${_param:keystone_service_host}
+            internal_port: 5000
+            internal_protocol: http
+            internal_path: '/v2.0'
+            admin_address: ${_param:keystone_service_host}
+            admin_port: 35357
+            admin_protocol: http
+            admin_path: '/v2.0'

--- a/classes/system/keystone/server/service/neutron.yml
+++ b/classes/system/keystone/server/service/neutron.yml
@@ -1,0 +1,24 @@
+parameters:
+  keystone:
+    server:
+      service:
+        neutron:
+          type: network
+          description: OpenStack Networking Service
+          user:
+            name: neutron
+            password: ${_param:keystone_neutron_password}
+          bind:
+            public_address: ${_param:neutron_service_host}
+            public_protocol: http
+            public_port: 9696
+            internal_address: ${_param:neutron_service_host}
+            internal_port: 9696
+            admin_address: ${_param:neutron_service_host}
+            admin_port: 9696
+            public_protocol: http
+            public_path: '/'
+            internal_protocol: http
+            internal_path: '/'
+            admin_protocol: http
+            admin_path: '/'

--- a/classes/system/keystone/server/service/nova.yml
+++ b/classes/system/keystone/server/service/nova.yml
@@ -1,0 +1,39 @@
+parameters:
+  keystone:
+    server:
+      service:
+        nova:
+          type: compute
+          description: OpenStack Compute Service
+          user:
+            name: nova
+            password: ${_param:keystone_nova_password}
+          bind:
+            public_address: ${_param:nova_service_host}
+            public_protocol: http
+            public_port: 8774
+            public_path: '/v2/$(tenant_id)s'
+            internal_address: ${_param:nova_service_host}
+            internal_port: 8774
+            internal_protocol: http
+            internal_path: '/v2/$(tenant_id)s'
+            admin_address: ${_param:nova_service_host}
+            admin_port: 8774
+            admin_protocol: http
+            admin_path: '/v2/$(tenant_id)s'
+        ec2:
+          type: ec2
+          description: OpenStack EC2 Service
+          bind:
+            public_address: ${_param:nova_service_host}
+            public_protocol: http
+            public_port: 8773
+            public_path: '/services/Cloud'
+            internal_address: ${_param:nova_service_host}
+            internal_port: 8773
+            internal_protocol: http
+            internal_path: '/services/Cloud'
+            admin_address: ${_param:nova_service_host}
+            admin_port: 8773
+            admin_protocol: http
+            admin_path: '/services/Admin'

--- a/classes/system/openstack/control/mk20.yml
+++ b/classes/system/openstack/control/mk20.yml
@@ -7,6 +7,13 @@ classes:
 - service.memcached.server.single
 - service.rabbitmq.server.cluster
 - system.keystone.server.cluster
+- system.keystone.server.service.keystone
+- system.keystone.server.service.ceilometer
+- system.keystone.server.service.glance
+- system.keystone.server.service.nova
+- system.keystone.server.service.neutron
+- system.keystone.server.service.cinder
+- system.keystone.server.service.heat
 - system.glance.control.cluster
 - system.nova.control.cluster
 - system.neutron.control.cluster

--- a/classes/system/openstack/control/mk22.yml
+++ b/classes/system/openstack/control/mk22.yml
@@ -7,6 +7,13 @@ classes:
 - service.memcached.server.single
 - service.rabbitmq.server.cluster
 - system.keystone.server.cluster
+- system.keystone.server.service.keystone
+- system.keystone.server.service.ceilometer
+- system.keystone.server.service.glance
+- system.keystone.server.service.nova
+- system.keystone.server.service.neutron
+- system.keystone.server.service.cinder
+- system.keystone.server.service.heat
 - system.glance.control.cluster
 - system.nova.control.cluster
 - system.neutron.control.cluster


### PR DESCRIPTION
I tried running the model but no keystone
services, tenants and users were added. This
patch takes the services from
https://github.com/tcpcloud/workshop-salt-model/
and includes them in mk20 and mk22 class.

Without this patch keystone will stay empty when the
keystone state is run.