### PR TITLE
Create keystone services when deploying keystone

### DIFF
--- a/classes/system/openstack/control/mk20.yml
+++ b/classes/system/openstack/control/mk20.yml
@@ -7,6 +7,7 @@ classes:
 - service.memcached.server.single
 - service.rabbitmq.server.cluster
 - system.keystone.server.cluster
+- system.keystone.client.single
 - system.glance.control.cluster
 - system.nova.control.cluster
 - system.neutron.control.cluster

--- a/classes/system/openstack/control/mk22.yml
+++ b/classes/system/openstack/control/mk22.yml
@@ -7,6 +7,7 @@ classes:
 - service.memcached.server.single
 - service.rabbitmq.server.cluster
 - system.keystone.server.cluster
+- system.keystone.client.single
 - system.glance.control.cluster
 - system.nova.control.cluster
 - system.neutron.control.cluster


### PR DESCRIPTION
Keystone service tenants, user and roles should be created
after we deploy keystone. This patch makes sure that the
keystone.client.service gets executed when executing
the keystone state on the controllers.

This patch seems nessecary because the service creation has
been moved from keystone.server.service to keystone.client.service
