### PR TITLE
Use stacklight branches for both basic & advanced

### DIFF
--- a/classes/system/salt/master/formula/git/openstack.yml
+++ b/classes/system/salt/master/formula/git/openstack.yml
@@ -11,15 +11,15 @@ parameters:
             cinder:
               source: git
               address: 'https://github.com/openstack/salt-formula-cinder.git'
-              revision: ${_param:salt_master_environment_revision}
+              revision: stacklight
             galera:
               source: git
               address: '${_param:salt_master_environment_repository}/salt-formula-galera.git'
-              revision: ${_param:salt_master_environment_revision}
+              revision: stacklight
             glance:
               source: git
               address: 'https://github.com/openstack/salt-formula-glance.git'
-              revision: ${_param:salt_master_environment_revision}
+              revision: stacklight
             glusterfs:
               source: git
               address: 'https://github.com/tcpcloud/salt-formula-glusterfs.git'
@@ -27,11 +27,11 @@ parameters:
             haproxy:
               source: git
               address: '${_param:salt_master_environment_repository}/salt-formula-haproxy.git'
-              revision: ${_param:salt_master_environment_revision}
+              revision: stacklight
             heat:
               source: git
               address: 'https://github.com/openstack/salt-formula-heat.git'
-              revision: ${_param:salt_master_environment_revision}
+              revision: stacklight
             horizon:
               source: git
               address: 'https://github.com/openstack/salt-formula-horizon.git'
@@ -43,11 +43,11 @@ parameters:
             keystone:
               source: git
               address: 'https://github.com/openstack/salt-formula-keystone.git'
-              revision: ${_param:salt_master_environment_revision}
+              revision: stacklight
             memcached:
               source: git
               address: '${_param:salt_master_environment_repository}/salt-formula-memcached.git'
-              revision: ${_param:salt_master_environment_revision}
+              revision: stacklight
             mongodb:
               source: git
               address: '${_param:salt_master_environment_repository}/salt-formula-mongodb.git'
@@ -63,7 +63,7 @@ parameters:
             neutron:
               source: git
               address: 'https://github.com/openstack/salt-formula-neutron.git'
-              revision: ${_param:salt_master_environment_revision}
+              revision: stacklight
             nginx:
               source: git
               address: '${_param:salt_master_environment_repository}/salt-formula-nginx.git'
@@ -71,7 +71,7 @@ parameters:
             nova:
               source: git
               address: 'https://github.com/openstack/salt-formula-nova.git'
-              revision: ${_param:salt_master_environment_revision}
+              revision: stacklight
             opencontrail:
               source: git
               address: 'https://github.com/openstack/salt-formula-opencontrail.git'

--- a/classes/system/salt/master/formula/git/saltstack.yml
+++ b/classes/system/salt/master/formula/git/saltstack.yml
@@ -23,7 +23,7 @@ parameters:
             ntp:
               source: git
               address: '${_param:salt_master_environment_repository}/salt-formula-ntp.git'
-              revision: ${_param:salt_master_environment_revision}
+              revision: stacklight
             openssh:
               source: git
               address: '${_param:salt_master_environment_repository}/salt-formula-openssh.git'

--- a/nodes/control/cfg01.mk20-stacklight-basic.local.yml
+++ b/nodes/control/cfg01.mk20-stacklight-basic.local.yml
@@ -30,32 +30,3 @@ parameters:
     system:
       name: cfg01
       domain: mk20-stacklight-basic.local
-  salt:
-    master:
-      environment:
-        dev:
-          formula:
-            linux:
-              revision: stacklight
-            ntp:
-              revision: stacklight
-            rabbitmq:
-              revision: stacklight
-            galera:
-              revision: stacklight
-            haproxy:
-              revision: stacklight
-            memcached:
-              revision: stacklight
-            cinder:
-              revision: stacklight
-            glance:
-              revision: stacklight
-            keystone:
-              revision: stacklight
-            heat:
-              revision: stacklight
-            nova:
-              revision: stacklight
-            neutron:
-              revision: stacklight


### PR DESCRIPTION
Instead of overriding "revision" at the config node level this commit sets "revision" in the system.salt.master.formula.git.openstack/saltstack classes directly. This is to be consistent with what was done in 7251fc9, and to use the StackLight branches for both stacklight-basic and stacklight-advanced.