### PR TITLE
Add influxdb_time_precision parameter

### DIFF
--- a/classes/system/heka/metric_collector/single.yml
+++ b/classes/system/heka/metric_collector/single.yml
@@ -3,9 +3,12 @@
 applications:
 - heka
 parameters:
+  _param:
+    influxdb_time_precision: ms
   heka:
     metric_collector:
       enabled: true
+      influxdb_time_precision: ${_param:influxdb_time_precision}
       output:
         influxdb:
           engine: influxdb
@@ -14,3 +17,4 @@ parameters:
           database: ${_param:influxdb_database}
           username: ${_param:influxdb_user}
           password: ${_param:influxdb_password}
+          time_precision: ${_param:influxdb_time_precision}


### PR DESCRIPTION
Set the InfluxDB time precision in the user model, and use one parameter for setting the time precision in both the InfluxDB output and the InfluxDB accumulator filter.

This depends on https://github.com/tcpcloud/salt-formula-heka/pull/17, which should be merged first.