### PR TITLE
Add Elasticsearch parameters

### DIFF
--- a/classes/system/elasticsearch/server/single.yml
+++ b/classes/system/elasticsearch/server/single.yml
@@ -20,7 +20,7 @@ parameters:
       enabled: true
       bind:
         address: ${_param:single_address}
-        port: 9200
+        port: ${_param:elasticsearch_port}
       mlockall: true
       threadpool:
         bulk:

--- a/classes/system/heka/log_collector/single.yml
+++ b/classes/system/heka/log_collector/single.yml
@@ -37,3 +37,8 @@ parameters:
         enabled: true
     log_collector:
       enabled: true
+      output:
+        elasticsearch:
+          engine: elasticsearch
+          host: ${_param:heka_elasticsearch_host}
+          port: ${_param:elasticsearch_port}

--- a/classes/system/openstack/common/mk20_stacklight.yml
+++ b/classes/system/openstack/common/mk20_stacklight.yml
@@ -77,6 +77,7 @@ parameters:
     mongodb_ceilometer_password: cloudlab
     mongodb_admin_password: cloudlab
     mongodb_shared_key: eoTh1AwahlahqueingeejooLughah4tei9feing0eeVaephooDi2li1TaeV1ooth
+    elasticsearch_port: 9200
     influxdb_port: 8086
     influxdb_database: lma
     influxdb_user: lma


### PR DESCRIPTION
Configure the Elasticsearch output on the log_collector.

This depends on https://github.com/tcpcloud/salt-formula-heka/pull/18, which should be merged first.