### PR TITLE
Properly set kibana_elasticsearch_host

### DIFF
--- a/classes/system/stacklight/server/cluster.yml
+++ b/classes/system/stacklight/server/cluster.yml
@@ -6,4 +6,4 @@ classes:
 - system.openstack.common.mk20_stacklight
 parameters:
   _param:
-    kibana_elasticsearch_host: localhost
+    kibana_elasticsearch_host: ${_param:monitor_vip_address}

--- a/classes/system/stacklight/server/single.yml
+++ b/classes/system/stacklight/server/single.yml
@@ -9,4 +9,4 @@ classes:
 - system.openstack.common.mk20_stacklight
 parameters:
   _param:
-    kibana_elasticsearch_host: localhost
+    kibana_elasticsearch_host: mon


### PR DESCRIPTION
This commit sets `kibana_elasticsearch_host` to "mon" in the
`stacklight.server.single` class and to `"${_param:monitor_vip_address}"` in the
`stacklight.server.cluster` class.