### PR TITLE
Enable Heka for glance, heat, keystone and neutron

### DIFF
--- a/classes/system/heka/log_collector/single.yml
+++ b/classes/system/heka/log_collector/single.yml
@@ -7,19 +7,7 @@ parameters:
     _support:
       heka:
         enabled: false
-  glance:
-    _support:
-      heka:
-        enabled: false
   elasticsearch:
-    _support:
-      heka:
-        enabled: false
-  heat:
-    _support:
-      heka:
-        enabled: false
-  keystone:
     _support:
       heka:
         enabled: false
@@ -27,10 +15,6 @@ parameters:
     _support:
       heka:
         enabled: true
-  neutron:
-    _support:
-      heka:
-        enabled: false
   heka:
     _support:
       heka:


### PR DESCRIPTION
Enable Heka for glance, heat, keystone and neutron now that the following are merged:

* https://review.openstack.org/#/c/391439/ (neutron)
* https://review.openstack.org/#/c/391433/ (glance)
* https://review.openstack.org/#/c/391436/ (heat)
* https://review.openstack.org/#/c/391470/ (keystone)

(We still don't collect Nova logs.)