### PR TITLE
Do not apply the remote_collector class

### DIFF
--- a/classes/system/heka/remote_collector/single.yml
+++ b/classes/system/heka/remote_collector/single.yml
@@ -1,6 +1,0 @@
-classes:
-- service.heka.remote_collector.single
-parameters:
-  collectd:
-    client:
-      remote_collector: true

--- a/classes/system/stacklight/server/single.yml
+++ b/classes/system/stacklight/server/single.yml
@@ -1,5 +1,4 @@
 classes:
-- system.heka.remote_collector.single
 - system.heka.aggregator.single
 - system.elasticsearch.server.single
 - system.influxdb.server.single
@@ -10,3 +9,6 @@ classes:
 parameters:
   _param:
     kibana_elasticsearch_host: mon
+  collectd:
+    client:
+      remote_collector: true


### PR DESCRIPTION
Deploying the `remote_collector` doesn't currently work. We don't need the `remote_collector` for now, so this commit just removes the `system.heka.remote_collector.single` class.

This is the error we currently get when applying the "heka" state on the monitoring node:

```
----------
          ID: /etc/remote_collector/output_metric_collector.toml
    Function: file.managed
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1733, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1652, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/states/file.py", line 1644, in managed
                  **kwargs
                File "/usr/lib/python2.7/dist-packages/salt/modules/file.py", line 3953, in check_managed_changes
                  **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/modules/file.py", line 3623, in get_managed
                  **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/utils/templates.py", line 178, in render_tmpl
                  output = render_str(tmplstr, context, tmplpath)
                File "/usr/lib/python2.7/dist-packages/salt/utils/templates.py", line 386, in render_jinja_tmpl
                  buf=tmplstr)
              SaltRenderError: Jinja variable 'salt.utils.odict.OrderedDict object' has no attribute 'message_matcher'
     Started: 10:12:47.712164
    Duration: 13.344 ms
     Changes:
```