### PR TITLE
Do not set time_precision on InfluxDB output

### DIFF
--- a/classes/system/heka/metric_collector/single.yml
+++ b/classes/system/heka/metric_collector/single.yml
@@ -3,12 +3,10 @@
 applications:
 - heka
 parameters:
-  _param:
-    influxdb_time_precision: ms
   heka:
     metric_collector:
       enabled: true
-      influxdb_time_precision: ${_param:influxdb_time_precision}
+      influxdb_time_precision: ms
       output:
         influxdb:
           engine: influxdb
@@ -17,4 +15,3 @@ parameters:
           database: ${_param:influxdb_database}
           username: ${_param:influxdb_user}
           password: ${_param:influxdb_password}
-          time_precision: ${_param:influxdb_time_precision}


### PR DESCRIPTION
With https://github.com/tcpcloud/salt-formula-heka/pull/19 the InfluxDB output configuration uses "influxdb_time_precision" set on "metric_collector".