### PR TITLE
Configure UTC timezone for StackLight labs

### DIFF
--- a/classes/system/openstack/common/mk20_stacklight.yml
+++ b/classes/system/openstack/common/mk20_stacklight.yml
@@ -83,3 +83,7 @@ parameters:
     influxdb_database: lma
     influxdb_user: lma
     influxdb_password: lmapass
+    linux_timezone: UTC
+  linux:
+    system:
+      timezone: ${_param:linux_timezone}


### PR DESCRIPTION
Because it doesn't work well currently in different timezones.