### PR TITLE
Remove nova section from log_collector.single class

### DIFF
--- a/classes/system/heka/log_collector/single.yml
+++ b/classes/system/heka/log_collector/single.yml
@@ -11,10 +11,6 @@ parameters:
     _support:
       heka:
         enabled: false
-  nova:
-    _support:
-      heka:
-        enabled: true
   heka:
     _support:
       heka:


### PR DESCRIPTION
This commit prevents the `log_collector` from looking for Nova logs on non-nova nodes.