### PR TITLE
Set grafana binding and rename datasource

### DIFF
--- a/classes/system/grafana/server/single.yml
+++ b/classes/system/grafana/server/single.yml
@@ -15,6 +15,9 @@ parameters:
   grafana:
     server:
       enabled: true
+      bind:
+        address: ${_param:single_address}
+        port: 3000
       database:
         engine: sqlite3
       auth:
@@ -34,7 +37,7 @@ parameters:
         user: ${_param:grafana_user}
         password: ${_param:grafana_password}
       datasource:
-        influxdb:
+        lma:
           type: influxdb
           host: ${_param:grafana_influxdb_host}
           port: ${_param:influxdb_port}


### PR DESCRIPTION
This patch renames datasource because the name of the datasource is
currently hardcoded into dashboards for annotations.