### PR TITLE
Configure the heka aggregator

### DIFF
--- a/classes/system/heka/aggregator/single.yml
+++ b/classes/system/heka/aggregator/single.yml
@@ -1,2 +1,15 @@
-classes:
-- service.heka.aggregator.single
+applications:
+- heka
+parameters:
+  heka:
+    aggregator:
+      enabled: true
+      influxdb_time_precision: ms
+      output:
+        influxdb:
+          engine: influxdb
+          host: ${_param:heka_influxdb_host}
+          port: ${_param:influxdb_port}
+          database: ${_param:influxdb_database}
+          username: ${_param:influxdb_user}
+          password: ${_param:influxdb_password}

--- a/classes/system/heka/metric_collector/single.yml
+++ b/classes/system/heka/metric_collector/single.yml
@@ -13,3 +13,6 @@ parameters:
           database: ${_param:influxdb_database}
           username: ${_param:influxdb_user}
           password: ${_param:influxdb_password}
+        aggregator:
+          engine: aggregator
+          host: ${_param:heka_aggregator_host}

--- a/classes/system/openstack/common/mk20_stacklight.yml
+++ b/classes/system/openstack/common/mk20_stacklight.yml
@@ -12,6 +12,7 @@ parameters:
     heka_amqp_password: workshop
     heka_elasticsearch_host: mon
     heka_influxdb_host: mon
+    heka_aggregator_host: mon
     grafana_influxdb_host: mon
     opencontrail_version: 3.0
     opencontrail_compute_dns: 8.8.8.8


### PR DESCRIPTION
This configures the heka aggregator on the monitoring node. This is a companion PR for https://github.com/tcpcloud/salt-formula-heka/pull/27, which needs to be merged first.