### PR TITLE
Enable remote dashboards

### DIFF
--- a/classes/system/grafana/server/single.yml
+++ b/classes/system/grafana/server/single.yml
@@ -26,7 +26,7 @@ parameters:
         user: ${_param:grafana_user}
         password: ${_param:grafana_password}
       dashboards:
-        enabled: true
+        enabled: false
         path: /var/lib/grafana/dashboards
     client:
       enabled: true
@@ -36,6 +36,8 @@ parameters:
         port: 3000
         user: ${_param:grafana_user}
         password: ${_param:grafana_password}
+      remote_data:
+        engine: 'salt_mine'
       datasource:
         lma:
           type: influxdb

--- a/classes/system/openstack/compute/mk20.yml
+++ b/classes/system/openstack/compute/mk20.yml
@@ -3,6 +3,7 @@ classes:
 - system.linux.system.repo.mos8
 - system.nova.compute.cluster
 - system.opencontrail.compute.cluster
+- service.grafana.collector
 parameters:
   _param:
     opencontrail_compute_gateway: 172.16.10.1

--- a/classes/system/openstack/control/mk20.yml
+++ b/classes/system/openstack/control/mk20.yml
@@ -14,6 +14,7 @@ classes:
 - system.heat.server.cluster
 - system.opencontrail.control.cluster
 - system.horizon.server.cluster
+- service.grafana.collector
 parameters:
   _param:
     keepalived_vip_interface: eth1

--- a/classes/system/stacklight/server/cluster.yml
+++ b/classes/system/stacklight/server/cluster.yml
@@ -4,6 +4,7 @@ classes:
 - system.kibana.server.single
 - system.grafana.server.single
 - system.openstack.common.mk20_stacklight
+- service.grafana.collector
 parameters:
   _param:
     kibana_elasticsearch_host: ${_param:monitor_vip_address}

--- a/classes/system/stacklight/server/single.yml
+++ b/classes/system/stacklight/server/single.yml
@@ -7,6 +7,7 @@ classes:
 - system.grafana.server.single
 - system.nagios.server.single
 - system.openstack.common.mk20_stacklight
+- service.grafana.collector
 parameters:
   _param:
     kibana_elasticsearch_host: mon


### PR DESCRIPTION
This patch activates the remote dashboards and disables the local
dashboards. All dashboards that are currently provided by the Grafana
formula will probably be provided by each service.