### PR TITLE
Adapt model to new Heka config mechanism

### DIFF
--- a/classes/system/heka/aggregator/single.yml
+++ b/classes/system/heka/aggregator/single.yml
@@ -3,11 +3,8 @@ classes:
 parameters:
   heka:
     aggregator:
-      output:
-        influxdb:
-          engine: influxdb
-          host: ${_param:heka_influxdb_host}
-          port: ${_param:influxdb_port}
-          database: ${_param:influxdb_database}
-          username: ${_param:influxdb_user}
-          password: ${_param:influxdb_password}
+      influxdb_host: ${_param:heka_influxdb_host}
+      influxdb_port: ${_param:influxdb_port}
+      influxdb_database: ${_param:influxdb_database}
+      influxdb_username: ${_param:influxdb_user}
+      influxdb_password: ${_param:influxdb_password}

--- a/classes/system/heka/log_collector/single.yml
+++ b/classes/system/heka/log_collector/single.yml
@@ -3,8 +3,5 @@ classes:
 parameters:
   heka:
     log_collector:
-      output:
-        elasticsearch:
-          engine: elasticsearch
-          host: ${_param:heka_elasticsearch_host}
-          port: ${_param:elasticsearch_port}
+      elasticsearch_host: ${_param:heka_elasticsearch_host}
+      elasticsearch_port: ${_param:elasticsearch_port}

--- a/classes/system/heka/metric_collector/single.yml
+++ b/classes/system/heka/metric_collector/single.yml
@@ -3,14 +3,10 @@ classes:
 parameters:
   heka:
     metric_collector:
-      output:
-        influxdb:
-          engine: influxdb
-          host: ${_param:heka_influxdb_host}
-          port: ${_param:influxdb_port}
-          database: ${_param:influxdb_database}
-          username: ${_param:influxdb_user}
-          password: ${_param:influxdb_password}
-        aggregator:
-          engine: aggregator
-          host: ${_param:heka_aggregator_host}
+      influxdb_host: ${_param:heka_influxdb_host}
+      influxdb_port: ${_param:influxdb_port}
+      influxdb_database: ${_param:influxdb_database}
+      influxdb_username: ${_param:influxdb_user}
+      influxdb_password: ${_param:influxdb_password}
+      aggregator_host: ${_param:heka_aggregator_host}
+      aggregator_port: ${_param:aggregator_port}

--- a/classes/system/heka/remote_collector/single.yml
+++ b/classes/system/heka/remote_collector/single.yml
@@ -3,11 +3,8 @@ classes:
 parameters:
   heka:
     remote_collector:
-      output:
-        influxdb:
-          engine: influxdb
-          host: ${_param:heka_influxdb_host}
-          port: ${_param:influxdb_port}
-          database: ${_param:influxdb_database}
-          username: ${_param:influxdb_user}
-          password: ${_param:influxdb_password}
+      influxdb_host: ${_param:heka_influxdb_host}
+      influxdb_port: ${_param:influxdb_port}
+      influxdb_database: ${_param:influxdb_database}
+      influxdb_username: ${_param:influxdb_user}
+      influxdb_password: ${_param:influxdb_password}

--- a/classes/system/openstack/common/mk20_stacklight.yml
+++ b/classes/system/openstack/common/mk20_stacklight.yml
@@ -84,6 +84,7 @@ parameters:
     influxdb_database: lma
     influxdb_user: lma
     influxdb_password: lmapass
+    aggregator_port: 5565
     linux_timezone: UTC
   linux:
     system:


### PR DESCRIPTION
This adapts the user model to the Heka configuration mechanism implemented in https://github.com/tcpcloud/salt-formula-heka/pull/38.