### PR TITLE
Enable aggregator output in remote collector

### DIFF
--- a/classes/system/heka/remote_collector/single.yml
+++ b/classes/system/heka/remote_collector/single.yml
@@ -8,3 +8,5 @@ parameters:
       influxdb_database: ${_param:influxdb_database}
       influxdb_username: ${_param:influxdb_user}
       influxdb_password: ${_param:influxdb_password}
+      aggregator_host: ${_param:heka_aggregator_host}
+      aggregator_port: ${_param:aggregator_port}


### PR DESCRIPTION
This enables the aggregator output in the remote collector. Requires https://github.com/tcpcloud/salt-formula-heka/pull/43.