### PR TITLE
Enable NTP mode7 queries for Trusty nodes too

### DIFF
--- a/classes/system/linux/system/trusty.yml
+++ b/classes/system/linux/system/trusty.yml
@@ -21,3 +21,6 @@ parameters:
           enabled: true
           type: eth
           proto: dhcp
+  ntp:
+    client:
+      mode7: true


### PR DESCRIPTION
Because otherwise the ntp collectd plugin isn't configured.