### PR TITLE
Add usage of multi computes

### DIFF
--- a/classes/cluster/mk22_qa_lab01/fuel/config.yml
+++ b/classes/cluster/mk22_qa_lab01/fuel/config.yml
@@ -12,7 +12,7 @@ classes:
 - system.mysql.client.single
 - system.reclass.storage.system.openstack_control_cluster
 - system.reclass.storage.system.openstack_database_cluster
-- system.reclass.storage.system.openstack_compute_single
+- system.reclass.storage.system.openstack_compute_multi
 - system.reclass.storage.system.openstack_dashboard_single
 - cluster.mk22_qa_lab01
 parameters:

--- a/classes/cluster/mk22_qa_lab01/init.yml
+++ b/classes/cluster/mk22_qa_lab01/init.yml
@@ -27,6 +27,11 @@ parameters:
           names:
           - cmp01
           - cmp01.${_param:cluster_domain}
+        cmp02:
+          address: 172.16.10.105
+          names:
+          - cmp02
+          - cmp02.${_param:cluster_domain}
     # Interface definitions
     linux_dhcp_interface:
       enabled: true


### PR DESCRIPTION
We have 2 computes spawned, but use openstack_compute_single,
replace it with multi one