### PR TITLE
Install InfluxDB on a single node

### DIFF
--- a/classes/system/openstack/common/mk20_stacklight.yml
+++ b/classes/system/openstack/common/mk20_stacklight.yml
@@ -11,9 +11,9 @@ parameters:
     heka_amqp_host: mon
     heka_amqp_password: workshop
     heka_elasticsearch_host: mon
-    heka_influxdb_host: mon
+    heka_influxdb_host: mon01
     heka_aggregator_host: mon
-    grafana_influxdb_host: mon
+    grafana_influxdb_host: mon01
     opencontrail_version: 3.0
     opencontrail_compute_dns: 8.8.8.8
     opencontrail_stats_password: contrail123

--- a/classes/system/reclass/storage/system/mk20_stacklight_advanced.yml
+++ b/classes/system/reclass/storage/system/mk20_stacklight_advanced.yml
@@ -63,6 +63,7 @@ parameters:
           classes:
           - system.linux.system.xenial
           - system.heka.aggregator.single
+          - system.influxdb.server.single
           - system.stacklight.server.cluster
           - system.openstack.common.mk20_stacklight_advanced
           params:

--- a/classes/system/stacklight/server/cluster.yml
+++ b/classes/system/stacklight/server/cluster.yml
@@ -1,6 +1,5 @@
 classes:
 - system.elasticsearch.server.cluster
-- system.influxdb.server.cluster
 - system.kibana.server.single
 - system.grafana.server.single
 - system.openstack.common.mk20_stacklight


### PR DESCRIPTION
This patch removes the declaration of InfluxDB clustering and install
InfluxDB only on mon01. There is no clustering with the new InfluxDB
server.