### PR TITLE
Fix /etc/host for the mon node

### DIFF
--- a/classes/system/openstack/common/mk20_stacklight_basic.yml
+++ b/classes/system/openstack/common/mk20_stacklight_basic.yml
@@ -33,11 +33,12 @@ parameters:
           - cmp01.mk20-stacklight-basic.local
         mon01:
           address: ${_param:monitor_address}
+          # Important! order matters
           names:
-          - mon
-          - mon.mk20-stacklight-basic.local
           - mon01
           - mon01.mk20-stacklight-basic.local
+          - mon.mk20-stacklight-basic.local
+          - mon
         ctl:
           address: 172.16.10.254
           names:


### PR DESCRIPTION
The monitoring node get 'mon' as hostname when using 'host' grains while it
should be 'mon01'.