### PR TITLE
Bind Kibana to a specific IP

### DIFF
--- a/classes/system/kibana/server/single.yml
+++ b/classes/system/kibana/server/single.yml
@@ -1,11 +1,12 @@
 classes:
 - service.kibana.server.single
 parameters:
-  _param:
-    kibana_elasticsearch_host: localhost
   kibana:
     server:
       enabled: true
+      bind:
+        address: ${_param:single_address}
+        port: ${_param:kibana_port}
       database:
         engine: elasticsearch
         host: ${_param:kibana_elasticsearch_host}

--- a/classes/system/monitoring/server/single.yml
+++ b/classes/system/monitoring/server/single.yml
@@ -13,4 +13,5 @@ classes:
 - system.monitoring.server.check.api
 parameters:
   _param:
+    kibana_port: 5601
     kibana_elasticsearch_host: localhost

--- a/classes/system/stacklight/server/cluster.yml
+++ b/classes/system/stacklight/server/cluster.yml
@@ -10,6 +10,7 @@ classes:
 - service.keepalived.support
 parameters:
   _param:
+    kibana_port: 5601
     kibana_elasticsearch_host: ${_param:monitor_vip_address}
   haproxy:
     proxy:

--- a/classes/system/stacklight/server/single.yml
+++ b/classes/system/stacklight/server/single.yml
@@ -10,6 +10,7 @@ classes:
 - service.grafana.collector
 parameters:
   _param:
+    kibana_port: 5601
     kibana_elasticsearch_host: mon
     collectd_remote_collector_host: 127.0.0.1
     collectd_remote_collector_port: 8326


### PR DESCRIPTION
This patch binds Kibana to single address instead of the default
0.0.0.0.