### PR TITLE
Sync Salt states and modules

### DIFF
--- a/scripts/fuel_infra_install.sh
+++ b/scripts/fuel_infra_install.sh
@@ -5,6 +5,11 @@ salt -C 'I@salt:master' state.sls salt.master,reclass
 
 # Refresh minion's pillar data
 salt '*' saltutil.refresh_pillar
+
+# Sync states and modules
+salt '*' saltutil.sync_states
+salt '*' saltutil.sync_modules
+
 sleep 5
 
 # Bootstrap all nodes


### PR DESCRIPTION
This is a PR for `Mirantis:bash`.

This PR modifies the `fuel_infra_install.sh` script to sync the states and modules defined in formulas to the minions.

ISSUE: this turns out to not be sufficient, a restart of salt-minion is still required for the minion to actually find the synchronized states/modules.