### PR TITLE
Deploy stacklight agents on all the nodes

### DIFF
--- a/classes/cluster/mk20_stacklight_basic/init.yml
+++ b/classes/cluster/mk20_stacklight_basic/init.yml
@@ -1,8 +1,9 @@
 classes:
 - system.linux.system.single
 - cluster.mk20_stacklight_basic.fuel
-- cluster.mk20_stacklight_basic.stacklight
 - cluster.mk20_stacklight_basic.openstack
+- cluster.mk20_stacklight_basic.stacklight
+- cluster.mk20_stacklight_basic.stacklight.client
 parameters:
   _param:
     cluster_domain: mk20-stacklight-basic.local

--- a/classes/cluster/mk20_stacklight_basic/stacklight/client.yml
+++ b/classes/cluster/mk20_stacklight_basic/stacklight/client.yml
@@ -3,3 +3,4 @@ classes:
 - system.heka.log_collector.single
 - system.heka.metric_collector.single
 - cluster.mk20_stacklight_basic.stacklight
+- service.grafana.collector

--- a/classes/cluster/mk20_stacklight_basic/stacklight/client.yml
+++ b/classes/cluster/mk20_stacklight_basic/stacklight/client.yml
@@ -2,4 +2,4 @@ classes:
 - system.collectd.client.output.heka
 - system.heka.log_collector.single
 - system.heka.metric_collector.single
-- cluster.mk20_stacklight_basic
+- cluster.mk20_stacklight_basic.stacklight

--- a/classes/system/collectd/client/remote.yml
+++ b/classes/system/collectd/client/remote.yml
@@ -1,6 +1,14 @@
 classes:
 - service.collectd.client
 parameters:
+  _param:
+    collectd_remote_collector_host: 127.0.0.1
+    collectd_remote_collector_port: 8326
   collectd:
     client:
       remote_collector: true
+      backend:
+        remote_collector:
+          engine: http
+          host: ${_param:collectd_remote_collector_host}
+          port: ${_param:collectd_remote_collector_port}


### PR DESCRIPTION
This is a PR for `Mirantis:dash`.

This fixes the `mk20_stacklight_basic.stacklight.client` class, and adds this class to the `mk20_stacklight_basic` class to deploy `collectd`, `log_collector` and `metric_collector` on all the nodes.