### PR TITLE
Update number of replicas for Elasticsearch

### DIFF
--- a/classes/system/elasticsearch/server/cluster.yml
+++ b/classes/system/elasticsearch/server/cluster.yml
@@ -22,14 +22,13 @@ parameters:
     server:
       enabled: true
       master: true
-      data: false
+      data: true
       mlockall: true
       bind:
         address: ${_param:single_address}
         port: 9200
       index:
-        shards: 1
-        replicas: 1
+        replicas: 2
       threadpool:
         bulk:
          queue_size: 1000


### PR DESCRIPTION
This patch sets the number of replicas according to the number of
instances.