### PR TITLE
Refresh modules between mine.flush and update

### DIFF
--- a/scripts/stacklight_infra_install.sh
+++ b/scripts/stacklight_infra_install.sh
@@ -7,6 +7,7 @@ salt "*" state.sls heka
 # Update salt-mine metadata definitions
 salt "*" state.sls salt.minion.grains
 salt "*" mine.flush
+salt "*" saltutil.refresh_modules
 salt "*" mine.update
 
 sleep 5


### PR DESCRIPTION
`saltutil.refresh_modules` makes salt-minion re-read the grains from `/etc/salt/grains`. That is a necessary step before pushing the grains to Salt Mine.