### PR TITLE
Change haproxy:proxy:listen config for StackLight

### DIFF
--- a/classes/cluster/mk20_lab_basic/openstack/control.yml
+++ b/classes/cluster/mk20_lab_basic/openstack/control.yml
@@ -76,6 +76,7 @@ parameters:
       listen:
         mysql_cluster:
           type: mysql
+          service_name: mysql
           binds:
           - address: ${_param:cluster_vip_address}
             port: 3306

--- a/classes/system/cinder/control/cluster.yml
+++ b/classes/system/cinder/control/cluster.yml
@@ -8,6 +8,7 @@ parameters:
       listen:
         cinder_api:
           type: openstack-service
+          service_name: cinder
           binds:
           - address: ${_param:cluster_vip_address}
             port: 8776

--- a/classes/system/galera/server/cluster.yml
+++ b/classes/system/galera/server/cluster.yml
@@ -7,6 +7,7 @@ parameters:
       listen:
         mysql_cluster:
           type: mysql
+          service_name: mysql
           binds:
           - address: ${_param:cluster_vip_address}
             port: 3306

--- a/classes/system/glance/control/cluster.yml
+++ b/classes/system/glance/control/cluster.yml
@@ -17,6 +17,7 @@ parameters:
       listen:
         glance_api:
           type: openstack-service
+          service_name: glance
           binds:
           - address: ${_param:cluster_vip_address}
             port: 9292
@@ -35,6 +36,7 @@ parameters:
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
         glance_registry:
           type: general-service
+          service_name: glance
           check: false
           binds:
           - address: ${_param:cluster_vip_address}

--- a/classes/system/glance/control/cluster.yml
+++ b/classes/system/glance/control/cluster.yml
@@ -34,7 +34,7 @@ parameters:
             host: ${_param:cluster_node03_address}
             port: 9292
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-        glance_registry:
+        glance_registry_api:
           type: general-service
           service_name: glance
           check: false

--- a/classes/system/haproxy/proxy/listen/elasticsearch.yml
+++ b/classes/system/haproxy/proxy/listen/elasticsearch.yml
@@ -4,6 +4,7 @@ parameters:
       listen:
         elasticsearch:
           mode: http
+          service_name: elasticsearch
           options:
             - forwardfor
             - httpchk

--- a/classes/system/haproxy/proxy/listen/kibana.yml
+++ b/classes/system/haproxy/proxy/listen/kibana.yml
@@ -4,6 +4,7 @@ parameters:
       listen:
         kibana:
           mode: http
+          service_name: kibana
           options:
             - forwardfor
 #            - httpchk

--- a/classes/system/haproxy/proxy/listen/rabbitmq.yml
+++ b/classes/system/haproxy/proxy/listen/rabbitmq.yml
@@ -4,6 +4,7 @@ parameters:
       listen:
         rabbitmq:
           type: rabbitmq
+          service_name: rabbitmq
           binds:
             - address: ${_param:cluster_vip_address}
               port: 5672
@@ -18,6 +19,7 @@ parameters:
               params: backup check
         rabbitmq_management:
           type: rabbitmq
+          service_name: rabbitmq
           binds:
             - address: ${_param:cluster_vip_address}
               port: 15672

--- a/classes/system/haproxy/proxy/listen/redis.yml
+++ b/classes/system/haproxy/proxy/listen/redis.yml
@@ -4,6 +4,7 @@ parameters:
       listen:
         redis:
           mode: tcp
+          service_name: redis
           balance: source
           binds:
             - address: ${_param:cluster_vip_address}

--- a/classes/system/heat/server/cluster.yml
+++ b/classes/system/heat/server/cluster.yml
@@ -8,6 +8,7 @@ parameters:
       listen:
         heat_api_cloudwatch:
           type: openstack-service
+          service_name: heat
           binds:
           - address: ${_param:cluster_vip_address}
             port: 8000
@@ -26,6 +27,7 @@ parameters:
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
         heat_api:
           type: openstack-service
+          service_name: heat
           binds:
           - address: ${_param:cluster_vip_address}
             port: 8004
@@ -44,6 +46,7 @@ parameters:
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
         heat_api_cfn:
           type: openstack-service
+          service_name: heat
           binds:
           - address: ${_param:cluster_vip_address}
             port: 8003

--- a/classes/system/heat/server/cluster.yml
+++ b/classes/system/heat/server/cluster.yml
@@ -6,7 +6,7 @@ parameters:
   haproxy:
     proxy:
       listen:
-        heat_api_cloudwatch:
+        heat_cloudwatch_api:
           type: openstack-service
           service_name: heat
           binds:
@@ -44,7 +44,7 @@ parameters:
             host: ${_param:cluster_node03_address}
             port: 8004
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-        heat_api_cfn:
+        heat_cfn_api:
           type: openstack-service
           service_name: heat
           binds:

--- a/classes/system/keystone/server/cluster.yml
+++ b/classes/system/keystone/server/cluster.yml
@@ -14,6 +14,7 @@ parameters:
       listen:
         keystone_auth:
           type: openstack-service
+          service_name: keystone
           binds:
           - address: ${_param:cluster_vip_address}
             port: 5000
@@ -32,6 +33,7 @@ parameters:
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
         keystone_admin:
           type: openstack-service
+          service_name: keystone
           binds:
           - address: ${_param:cluster_vip_address}
             port: 35357

--- a/classes/system/keystone/server/cluster.yml
+++ b/classes/system/keystone/server/cluster.yml
@@ -12,7 +12,7 @@ parameters:
   haproxy:
     proxy:
       listen:
-        keystone_auth:
+        keystone_public_api:
           type: openstack-service
           service_name: keystone
           binds:
@@ -31,7 +31,7 @@ parameters:
             host: ${_param:cluster_node03_address}
             port: 5000
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-        keystone_admin:
+        keystone_admin_api:
           type: openstack-service
           service_name: keystone
           binds:

--- a/classes/system/neutron/control/cluster.yml
+++ b/classes/system/neutron/control/cluster.yml
@@ -22,6 +22,7 @@ parameters:
       listen:
         neutron_api:
           type: openstack-service
+          service_name: neutron
           binds:
           - address: ${_param:cluster_vip_address}
             port: 9696

--- a/classes/system/nova/control/cluster.yml
+++ b/classes/system/nova/control/cluster.yml
@@ -13,6 +13,7 @@ parameters:
       listen:
         nova_ec2_api:
           type: general-service
+          service_name: nova
           check: false
           binds:
           - address: ${_param:cluster_vip_address}
@@ -32,6 +33,7 @@ parameters:
             params: check
         nova_openstack_api:
           type: openstack-service
+          service_name: nova
           binds:
           - address: ${_param:cluster_vip_address}
             port: 8774

--- a/classes/system/nova/control/cluster.yml
+++ b/classes/system/nova/control/cluster.yml
@@ -31,7 +31,7 @@ parameters:
             host: ${_param:cluster_node03_address}
             port: 8773
             params: check
-        nova_openstack_api:
+        nova_api:
           type: openstack-service
           service_name: nova
           binds:
@@ -50,7 +50,7 @@ parameters:
             host: ${_param:cluster_node03_address}
             port: 8774
             params: check inter 10s fastinter 2s downinter 3s rise 3 fall 3
-        nova_metadata:
+        nova_metadata_api:
           type: openstack-service
           binds:
           - address: ${_param:cluster_vip_address}

--- a/classes/system/opencontrail/control/analytics.yml
+++ b/classes/system/opencontrail/control/analytics.yml
@@ -16,6 +16,7 @@ parameters:
       listen:
         contrail_analytics:
           type: contrail-analytics
+          service_name: contrail
           binds:
           - address: ${_param:cluster_vip_address}
             port: 8081
@@ -34,6 +35,7 @@ parameters:
             params: check inter 2000 rise 2 fall 3
         contrail_config_stats:
           type: contrail-config
+          service_name: contrail
           format: listen
           binds:
           - address: '*'
@@ -42,6 +44,7 @@ parameters:
           password: ${_param:opencontrail_stats_password}
         contrail_openstack_stats:
           type: contrail-config
+          service_name: contrail
           format: listen
           binds:
           - address: '*'
@@ -50,6 +53,7 @@ parameters:
           password: ${_param:opencontrail_stats_password}
         contrail_collector_stats:
           type: contrail-config
+          service_name: contrail
           format: listen
           binds:
           - address: '*'

--- a/classes/system/opencontrail/control/cluster.yml
+++ b/classes/system/opencontrail/control/cluster.yml
@@ -16,6 +16,7 @@ parameters:
       listen:
         contrail_api:
           type: contrail-api
+          service_name: contrail
           check: false
           binds:
           - address: ${_param:cluster_vip_address}
@@ -35,6 +36,7 @@ parameters:
             params: check inter 2000 rise 2 fall 3
         contrail_discovery:
           type: contrail-api
+          service_name: contrail
           binds:
           - address: ${_param:cluster_vip_address}
             port: 5998
@@ -53,6 +55,7 @@ parameters:
             params: check inter 2000 rise 2 fall 3
         contrail_analytics:
           type: contrail-analytics
+          service_name: contrail
           binds:
           - address: ${_param:cluster_vip_address}
             port: 8081
@@ -71,6 +74,7 @@ parameters:
             params: check inter 2000 rise 2 fall 3
         contrail_config_stats:
           type: contrail-config
+          service_name: contrail
           format: listen
           binds:
           - address: '*'
@@ -79,6 +83,7 @@ parameters:
           password: ${_param:opencontrail_stats_password}
         contrail_openstack_stats:
           type: contrail-config
+          service_name: contrail
           format: listen
           binds:
           - address: '*'
@@ -87,6 +92,7 @@ parameters:
           password: ${_param:opencontrail_stats_password}
         contrail_collector_stats:
           type: contrail-config
+          service_name: contrail
           format: listen
           binds:
           - address: '*'

--- a/classes/system/opencontrail/control/control.yml
+++ b/classes/system/opencontrail/control/control.yml
@@ -7,6 +7,7 @@ parameters:
       listen:
         contrail_api:
           type: contrail-api
+          service_name: contrail
           check: false
           binds:
           - address: ${_param:cluster_vip_address}
@@ -26,6 +27,7 @@ parameters:
             params: check inter 2000 rise 2 fall 3
         contrail_discovery:
           type: contrail-api
+          service_name: contrail
           binds:
           - address: ${_param:cluster_vip_address}
             port: 5998
@@ -44,6 +46,7 @@ parameters:
             params: check inter 2000 rise 2 fall 3
         contrail_config_stats:
           type: contrail-config
+          service_name: contrail
           format: listen
           binds:
           - address: '*'
@@ -52,6 +55,7 @@ parameters:
           password: ${_param:opencontrail_stats_password}
         contrail_openstack_stats:
           type: contrail-config
+          service_name: contrail
           format: listen
           binds:
           - address: '*'
@@ -60,6 +64,7 @@ parameters:
           password: ${_param:opencontrail_stats_password}
         contrail_collector_stats:
           type: contrail-config
+          service_name: contrail
           format: listen
           binds:
           - address: '*'

--- a/classes/system/opencontrail/control/single.yml
+++ b/classes/system/opencontrail/control/single.yml
@@ -15,6 +15,7 @@ parameters:
       listen:
         contrail_api:
           type: contrail-api
+          service_name: contrail
           check: false
           binds:
           - address: ${_param:single_address}
@@ -26,6 +27,7 @@ parameters:
             params: check inter 2000 rise 2 fall 3
         contrail_discovery:
           type: contrail-api
+          service_name: contrail
           binds:
           - address: ${_param:single_address}
             port: 5998
@@ -36,6 +38,7 @@ parameters:
             params: check inter 2000 rise 2 fall 3
         contrail_config_stats:
           type: contrail-config
+          service_name: contrail
           format: listen
           binds:
           - address: '*'
@@ -44,6 +47,7 @@ parameters:
           password: ${_param:opencontrail_stats_password}
         contrail_openstack_stats:
           type: contrail-config
+          service_name: contrail
           format: listen
           binds:
           - address: '*'
@@ -52,6 +56,7 @@ parameters:
           password: ${_param:opencontrail_stats_password}
         contrail_collector_stats:
           type: contrail-config
+          service_name: contrail
           format: listen
           binds:
           - address: '*'


### PR DESCRIPTION
This changes the `haproxy:proxy:listen` configuration for StackLight. More specifically:

* set `service_name` for aggregations in StackLight (see https://github.com/tcpcloud/salt-formula-haproxy/pull/11)
* use more consistent listen names