### PR TITLE
Fix InfluxDB repo and use single instead of cluster

### DIFF
--- a/classes/cluster/mk20_stacklight_advanced/stacklight/server.yml
+++ b/classes/cluster/mk20_stacklight_advanced/stacklight/server.yml
@@ -1,7 +1,6 @@
 classes:
 - system.collectd.client.remote
 - system.elasticsearch.server.cluster
-- system.influxdb.server.cluster
 - system.kibana.server.single
 - system.grafana.server.single
 - cluster.mk20_stacklight_advanced

--- a/classes/system/influxdb/server/cluster.yml
+++ b/classes/system/influxdb/server/cluster.yml
@@ -3,11 +3,12 @@ classes:
 - service.influxdb.server.single
 parameters:
   linux:
-    repo:
-      influxdb:
-        enabled: true
-        source: 'deb https://repos.influxdata.com/ubuntu xenial stable'
-        key_url: 'https://repos.influxdata.com/influxdb.key'
+    system:
+      repo:
+        influxdb:
+          enabled: true
+          source: 'deb https://repos.influxdata.com/ubuntu xenial stable'
+          key_url: 'https://repos.influxdata.com/influxdb.key'
   influxdb:
     server:
       enabled: true

--- a/classes/system/reclass/storage/system/stacklight_server_cluster.yml
+++ b/classes/system/reclass/storage/system/stacklight_server_cluster.yml
@@ -7,6 +7,7 @@ parameters:
           domain: ${_param:cluster_domain}
           classes:
           - cluster.${_param:cluster_name}.stacklight.server
+          - system.influxdb.server.single
           params:
             salt_master_host: ${_param:reclass_config_master}
             linux_system_codename: xenial


### PR DESCRIPTION
This patch fixes an error in the declaration of the repositorie. We also
use the single deployment instead of the cluster one because there is no
more cluster in the new InfluxDB version.