### PR TITLE
Enable NTP mode7 queries by default

### DIFF
--- a/classes/system/linux/system/single.yml
+++ b/classes/system/linux/system/single.yml
@@ -1,8 +1,8 @@
 classes:
 - service.linux.system
-- service.ntp.client
 - service.salt.minion.master
 - system.openssh.server.single
+- system.ntp.client.single
 - system.linux.system.repo.tcp_base
 parameters:
   linux:

--- a/classes/system/ntp/client/single.yml
+++ b/classes/system/ntp/client/single.yml
@@ -1,0 +1,6 @@
+classes:
+- service.ntp.client
+parameters:
+  ntp:
+    client:
+      mode7: true


### PR DESCRIPTION
Because otherwise the ntp collectd plugin isn't configured.