### PR TITLE
Add tmpfs for wal, fix elasticsearch address

### DIFF
--- a/classes/cluster/mk20_stacklight_basic/stacklight/server.yml
+++ b/classes/cluster/mk20_stacklight_basic/stacklight/server.yml
@@ -9,7 +9,7 @@ classes:
 - cluster.mk20_stacklight_basic
 parameters:
   _param:
-    kibana_elasticsearch_host: localhost
+    kibana_elasticsearch_host: ${_param:stacklight_monitor_address}
   linux:
     network:
       interface:

--- a/classes/system/influxdb/server/single.yml
+++ b/classes/system/influxdb/server/single.yml
@@ -1,5 +1,6 @@
 classes:
 - service.influxdb.server.single
+- system.influxdb.server.tmpfs_wal
 parameters:
   linux:
     system:


### PR DESCRIPTION
- Set mounting tmpfs by default 
- For access to elasticsearch we should use the same address as bind address, not localhost