### PR TITLE
Fix the use of the StackLight branches

### DIFF
--- a/classes/cluster/mk20_stacklight_advanced/fuel/config.yml
+++ b/classes/cluster/mk20_stacklight_advanced/fuel/config.yml
@@ -61,27 +61,58 @@ parameters:
               revision: stacklight
             collectd:
               revision: stacklight
+            elasticsearch:
+              revision: stacklight
             galera:
               revision: stacklight
             glance:
               revision: stacklight
+            glusterfs:
+              revision: stacklight
+            grafana:
+              revision: stacklight
+              state:
+                grafana3_datasource.py:
+                  enabled: true
+                grafana3_dashboard.py:
+                  enabled: true
             haproxy:
               revision: stacklight
             heat:
               revision: stacklight
             heka:
               revision: stacklight
+              module:
+                heka_alarming.py:
+                  enabled: true
+            influxdb:
+              revision: stacklight
             keystone:
+              revision: stacklight
+            kibana:
               revision: stacklight
             linux:
               revision: stacklight
+              module:
+                linux_netlink.py:
+                  enabled: true
             memcached:
               revision: stacklight
+            nagios:
+              module:
+                nagios_alarming.py:
+                  enabled: true
             neutron:
+              revision: stacklight
+            nginx:
               revision: stacklight
             nova:
               revision: stacklight
             ntp:
               revision: stacklight
+            opencontrail:
+              revision: stacklight
             rabbitmq:
+              revision: stacklight
+            swift:
               revision: stacklight

--- a/classes/cluster/mk20_stacklight_basic/fuel/config.yml
+++ b/classes/cluster/mk20_stacklight_basic/fuel/config.yml
@@ -61,27 +61,58 @@ parameters:
               revision: stacklight
             collectd:
               revision: stacklight
+            elasticsearch:
+              revision: stacklight
             galera:
               revision: stacklight
             glance:
               revision: stacklight
+            glusterfs:
+              revision: stacklight
+            grafana:
+              revision: stacklight
+              state:
+                grafana3_datasource.py:
+                  enabled: true
+                grafana3_dashboard.py:
+                  enabled: true
             haproxy:
               revision: stacklight
             heat:
               revision: stacklight
             heka:
               revision: stacklight
+              module:
+                heka_alarming.py:
+                  enabled: true
+            influxdb:
+              revision: stacklight
             keystone:
+              revision: stacklight
+            kibana:
               revision: stacklight
             linux:
               revision: stacklight
+              module:
+                linux_netlink.py:
+                  enabled: true
             memcached:
               revision: stacklight
+            nagios:
+              module:
+                nagios_alarming.py:
+                  enabled: true
             neutron:
+              revision: stacklight
+            nginx:
               revision: stacklight
             nova:
               revision: stacklight
             ntp:
               revision: stacklight
+            opencontrail:
+              revision: stacklight
             rabbitmq:
+              revision: stacklight
+            swift:
               revision: stacklight

--- a/classes/cluster/mk22_lab_advanced/fuel/config.yml
+++ b/classes/cluster/mk22_lab_advanced/fuel/config.yml
@@ -50,3 +50,67 @@ parameters:
           - service.galera.slave.cluster
           params:
             mysql_cluster_role: slave
+  salt:
+    master:
+      environment:
+        dev:
+          formula:
+            cinder:
+              revision: stacklight
+            collectd:
+              revision: stacklight
+            elasticsearch:
+              revision: stacklight
+            galera:
+              revision: stacklight
+            glance:
+              revision: stacklight
+            glusterfs:
+              revision: stacklight
+            grafana:
+              revision: stacklight
+              state:
+                grafana3_datasource.py:
+                  enabled: true
+                grafana3_dashboard.py:
+                  enabled: true
+            haproxy:
+              revision: stacklight
+            heat:
+              revision: stacklight
+            heka:
+              revision: stacklight
+              module:
+                heka_alarming.py:
+                  enabled: true
+            influxdb:
+              revision: stacklight
+            keystone:
+              revision: stacklight
+            kibana:
+              revision: stacklight
+            linux:
+              revision: stacklight
+              module:
+                linux_netlink.py:
+                  enabled: true
+            memcached:
+              revision: stacklight
+            nagios:
+              module:
+                nagios_alarming.py:
+                  enabled: true
+            neutron:
+              revision: stacklight
+            nginx:
+              revision: stacklight
+            nova:
+              revision: stacklight
+            ntp:
+              revision: stacklight
+            opencontrail:
+              revision: stacklight
+            rabbitmq:
+              revision: stacklight
+            swift:
+              revision: stacklight

--- a/classes/system/salt/master/formula/git/openstack.yml
+++ b/classes/system/salt/master/formula/git/openstack.yml
@@ -11,15 +11,15 @@ parameters:
             cinder:
               source: git
               address: 'https://github.com/openstack/salt-formula-cinder.git'
-              revision: stacklight
+              revision: ${_param:salt_master_environment_revision}
             galera:
               source: git
               address: '${_param:salt_master_environment_repository}/salt-formula-galera.git'
-              revision: stacklight
+              revision: ${_param:salt_master_environment_revision}
             glance:
               source: git
               address: 'https://github.com/openstack/salt-formula-glance.git'
-              revision: stacklight
+              revision: ${_param:salt_master_environment_revision}
             glusterfs:
               source: git
               address: 'https://github.com/tcpcloud/salt-formula-glusterfs.git'
@@ -27,11 +27,11 @@ parameters:
             haproxy:
               source: git
               address: '${_param:salt_master_environment_repository}/salt-formula-haproxy.git'
-              revision: stacklight
+              revision: ${_param:salt_master_environment_revision}
             heat:
               source: git
               address: 'https://github.com/openstack/salt-formula-heat.git'
-              revision: stacklight
+              revision: ${_param:salt_master_environment_revision}
             horizon:
               source: git
               address: 'https://github.com/openstack/salt-formula-horizon.git'
@@ -39,15 +39,15 @@ parameters:
             keepalived:
               source: git
               address: '${_param:salt_master_environment_repository}/salt-formula-keepalived.git'
-              revision: stacklight
+              revision: ${_param:salt_master_environment_revision}
             keystone:
               source: git
               address: 'https://github.com/openstack/salt-formula-keystone.git'
-              revision: stacklight
+              revision: ${_param:salt_master_environment_revision}
             memcached:
               source: git
               address: '${_param:salt_master_environment_repository}/salt-formula-memcached.git'
-              revision: stacklight
+              revision: ${_param:salt_master_environment_revision}
             mongodb:
               source: git
               address: '${_param:salt_master_environment_repository}/salt-formula-mongodb.git'
@@ -63,15 +63,15 @@ parameters:
             neutron:
               source: git
               address: 'https://github.com/openstack/salt-formula-neutron.git'
-              revision: stacklight
+              revision: ${_param:salt_master_environment_revision}
             nginx:
               source: git
               address: '${_param:salt_master_environment_repository}/salt-formula-nginx.git'
-              revision: stacklight
+              revision: ${_param:salt_master_environment_revision}
             nova:
               source: git
               address: 'https://github.com/openstack/salt-formula-nova.git'
-              revision: stacklight
+              revision: ${_param:salt_master_environment_revision}
             opencontrail:
               source: git
               address: 'https://github.com/openstack/salt-formula-opencontrail.git'
@@ -91,4 +91,4 @@ parameters:
             swift:
               source: git
               address: 'https://github.com/openstack/salt-formula-swift.git'
-              revision: stacklight
+              revision: ${_param:salt_master_environment_revision}

--- a/classes/system/salt/master/formula/git/saltstack.yml
+++ b/classes/system/salt/master/formula/git/saltstack.yml
@@ -22,15 +22,12 @@ parameters:
               revision: ${_param:salt_master_environment_revision}
             linux:
               source: git
-              module:
-                linux_netlink.py:
-                  enabled: true
               address: '${_param:salt_master_environment_repository}/salt-formula-linux.git'
               revision: ${_param:salt_master_environment_revision}
             ntp:
               source: git
               address: '${_param:salt_master_environment_repository}/salt-formula-ntp.git'
-              revision: stacklight
+              revision: ${_param:salt_master_environment_revision}
             openssh:
               source: git
               address: '${_param:salt_master_environment_repository}/salt-formula-openssh.git'

--- a/classes/system/salt/master/formula/git/stacklight.yml
+++ b/classes/system/salt/master/formula/git/stacklight.yml
@@ -11,20 +11,15 @@ parameters:
             collectd:
               source: git
               address: '${_param:salt_master_environment_repository}/salt-formula-collectd.git'
-              revision: stacklight
+              revision: ${_param:salt_master_environment_revision}
             elasticsearch:
               source: git
               address: '${_param:salt_master_environment_repository}/salt-formula-elasticsearch.git'
-              revision: stacklight
+              revision: ${_param:salt_master_environment_revision}
             grafana:
               source: git
               address: '${_param:salt_master_environment_repository}/salt-formula-grafana.git'
-              revision: stacklight
-              state:
-                grafana3_datasource.py:
-                  enabled: true
-                grafana3_dashboard.py:
-                  enabled: true
+              revision: ${_param:salt_master_environment_revision}
             graphite:
               source: git
               address: '${_param:salt_master_environment_repository}/salt-formula-graphite.git'
@@ -33,13 +28,10 @@ parameters:
               source: git
               address: '${_param:salt_master_environment_repository}/salt-formula-heka.git'
               revision: ${_param:salt_master_environment_revision}
-              module:
-                heka_alarming.py:
-                  enabled: true
             influxdb:
               source: git
               address: '${_param:salt_master_environment_repository}/salt-formula-influxdb.git'
-              revision: stacklight
+              revision: ${_param:salt_master_environment_revision}
             java:
               source: git
               address: '${_param:salt_master_environment_repository}/salt-formula-java.git'
@@ -50,9 +42,6 @@ parameters:
               revision: ${_param:salt_master_environment_revision}
             nagios:
               source: git
-              module:
-                nagios_alarming.py:
-                  enabled: true
               address: '${_param:salt_master_environment_repository}/salt-formula-nagios.git'
               revision: ${_param:salt_master_environment_revision}
             postgresql:
@@ -74,8 +63,4 @@ parameters:
             sensu:
               source: git
               address: '${_param:salt_master_environment_repository}/salt-formula-sensu.git'
-              revision: ${_param:salt_master_environment_revision}
-            nagios:
-              source: git
-              address: '${_param:salt_master_environment_repository}/salt-formula-nagios.git'
               revision: ${_param:salt_master_environment_revision}


### PR DESCRIPTION
Although this change introduces some duplication in the definition of the labs, it is necessary if labs other than the StackLight ones want to be deployed using Git formulas.