### PR TITLE
Enable Elasticsearch client for StackLight

### DIFF
--- a/classes/system/elasticsearch/client/single.yml
+++ b/classes/system/elasticsearch/client/single.yml
@@ -1,0 +1,8 @@
+classes:
+- service.elasticsearch.client
+parameters:
+  elasticsearch:
+    client:
+      enabled: true
+      server:
+        host: ${_param:stacklight_monitor_address}

--- a/classes/system/reclass/storage/system/stacklight_server_cluster.yml
+++ b/classes/system/reclass/storage/system/stacklight_server_cluster.yml
@@ -8,6 +8,7 @@ parameters:
           classes:
           - cluster.${_param:cluster_name}.stacklight.server
           - system.influxdb.server.single
+          - system.elasticsearch.client.single
           params:
             salt_master_host: ${_param:reclass_config_master}
             linux_system_codename: xenial

--- a/classes/system/reclass/storage/system/stacklight_server_single.yml
+++ b/classes/system/reclass/storage/system/stacklight_server_single.yml
@@ -7,6 +7,7 @@ parameters:
           domain: ${_param:cluster_domain}
           classes:
           - cluster.${_param:cluster_name}.stacklight.server
+          - system.elasticsearch.client.single
           params:
             salt_master_host: ${_param:reclass_config_master}
             linux_system_codename: xenial


### PR DESCRIPTION
This patch classifies Elasticsearch client on mon01.