### PR TITLE
Fix the infinite recursion for stacklight.client

### DIFF
--- a/classes/cluster/mk22_full_scale/stacklight/client.yml
+++ b/classes/cluster/mk22_full_scale/stacklight/client.yml
@@ -2,5 +2,5 @@ classes:
 - system.collectd.client.output.heka
 - system.heka.log_collector.single
 - system.heka.metric_collector.single
-- cluster.mk22_full_scale
+- cluster.mk22_full_scale.stacklight
 - service.grafana.collector

--- a/classes/cluster/mk22_lab_advanced/stacklight/client.yml
+++ b/classes/cluster/mk22_lab_advanced/stacklight/client.yml
@@ -2,5 +2,5 @@ classes:
 - system.collectd.client.output.heka
 - system.heka.log_collector.single
 - system.heka.metric_collector.single
-- cluster.mk22_lab_advanced
+- cluster.mk22_lab_advanced.stacklight
 - service.grafana.collector

--- a/classes/cluster/mk22_lab_advanced/stacklight/init.yml
+++ b/classes/cluster/mk22_lab_advanced/stacklight/init.yml
@@ -8,6 +8,7 @@ parameters:
     grafana_password: password
     grafana_influxdb_host: mon
     elasticsearch_port: 9200
+    influxdb_stacklight_password: lmapass
     influxdb_port: 8086
     influxdb_database: lma
     influxdb_user: lma


### PR DESCRIPTION
BTW, the param `influxdb_stacklight_password` should be named differently IMHO.
This has been renamed by this commit e21bcd962a0dca82e259e19e896f06d9b4c74766

@cznewt  why not just name it `ìnfluxdb_password` ?