### PR TITLE
Include default branch and repo for Git formulas

### DIFF
--- a/classes/cluster/mk20_stacklight_advanced/fuel/config.yml
+++ b/classes/cluster/mk20_stacklight_advanced/fuel/config.yml
@@ -18,8 +18,6 @@ classes:
 - cluster.mk20_stacklight_advanced
 parameters:
   _param:
-    salt_master_environment_repository: "https://github.com/tcpcloud"
-    salt_master_environment_revision: master
     reclass_data_repository: "git@github.com:Mirantis/mk-lab-salt-model.git"
     reclass_data_revision: master
     reclass_config_master: 192.168.10.100

--- a/classes/cluster/mk20_stacklight_basic/fuel/config.yml
+++ b/classes/cluster/mk20_stacklight_basic/fuel/config.yml
@@ -18,8 +18,6 @@ classes:
 - cluster.mk20_stacklight_basic
 parameters:
   _param:
-    salt_master_environment_repository: "https://github.com/tcpcloud"
-    salt_master_environment_revision: master
     salt_master_base_environment: dev
     reclass_data_repository: "git@github.com:Mirantis/mk-lab-salt-model.git"
     reclass_data_revision: master

--- a/classes/cluster/mk22_full_scale/fuel/config.yml
+++ b/classes/cluster/mk22_full_scale/fuel/config.yml
@@ -18,8 +18,6 @@ classes:
 - cluster.mk22_full_scale
 parameters:
   _param:
-    salt_master_environment_repository: "https://github.com/tcpcloud"
-    salt_master_environment_revision: master
     salt_master_base_environment: dev
     reclass_data_repository: "git@github.com:Mirantis/mk-lab-salt-model.git"
     reclass_data_revision: master

--- a/classes/cluster/mk22_scale_mirantis/fuel/config.yml
+++ b/classes/cluster/mk22_scale_mirantis/fuel/config.yml
@@ -17,8 +17,6 @@ classes:
 - cluster.mk22_scale_mirantis
 parameters:
   _param:
-    salt_master_environment_repository: "https://github.com/tcpcloud"
-    salt_master_environment_revision: master
     salt_master_base_environment: dev
     reclass_data_repository: "https://github.com/Mirantis/mk-lab-salt-model.git"
     reclass_data_revision: master

--- a/classes/system/salt/master/git.yml
+++ b/classes/system/salt/master/git.yml
@@ -3,3 +3,7 @@ classes:
 - system.salt.master.formula.git.openstack
 - system.salt.master.formula.git.saltstack
 - system.salt.master.formula.git.stacklight
+parameters:
+  _param:
+    salt_master_environment_repository: "https://github.com/tcpcloud"
+    salt_master_environment_revision: master


### PR DESCRIPTION
Otherwise all labs have to define 'salt_master_environment_repository'
and 'salt_master_environment_revision' even though they don't use the
Git formulas.