### PR TITLE
Use MySQL/Galera for Grafana

### DIFF
--- a/classes/cluster/mk20_lab_advanced/openstack/init.yml
+++ b/classes/cluster/mk20_lab_advanced/openstack/init.yml
@@ -48,6 +48,7 @@ parameters:
     mysql_cinder_password: workshop
     mysql_ceilometer_password: workshop
     mysql_glance_password: workshop
+    mysql_grafana_password: workshop
     mysql_heat_password: workshop
     mysql_keystone_password: workshop
     mysql_neutron_password: workshop

--- a/classes/cluster/mk20_stacklight_advanced/openstack/control.yml
+++ b/classes/cluster/mk20_stacklight_advanced/openstack/control.yml
@@ -16,6 +16,7 @@ classes:
 - system.galera.server.database.ceilometer
 - system.galera.server.database.cinder
 - system.galera.server.database.glance
+- system.galera.server.database.grafana
 - system.galera.server.database.heat
 - system.galera.server.database.keystone
 - system.galera.server.database.nova

--- a/classes/cluster/mk20_stacklight_advanced/openstack/init.yml
+++ b/classes/cluster/mk20_stacklight_advanced/openstack/init.yml
@@ -46,6 +46,7 @@ parameters:
     mysql_cinder_password: workshop
     mysql_ceilometer_password: workshop
     mysql_glance_password: workshop
+    mysql_grafana_password: workshop
     mysql_heat_password: workshop
     mysql_keystone_password: workshop
     mysql_neutron_password: workshop

--- a/classes/cluster/mk20_stacklight_basic/openstack/control.yml
+++ b/classes/cluster/mk20_stacklight_basic/openstack/control.yml
@@ -16,6 +16,7 @@ classes:
 - system.galera.server.database.ceilometer
 - system.galera.server.database.cinder
 - system.galera.server.database.glance
+- system.galera.server.database.grafana
 - system.galera.server.database.heat
 - system.galera.server.database.keystone
 - system.galera.server.database.nova

--- a/classes/cluster/mk20_stacklight_basic/openstack/init.yml
+++ b/classes/cluster/mk20_stacklight_basic/openstack/init.yml
@@ -44,6 +44,7 @@ parameters:
     mysql_cinder_password: workshop
     mysql_ceilometer_password: workshop
     mysql_glance_password: workshop
+    mysql_grafana_password: workshop
     mysql_heat_password: workshop
     mysql_keystone_password: workshop
     mysql_neutron_password: workshop

--- a/classes/cluster/mk22_lab_advanced/openstack/control.yml
+++ b/classes/cluster/mk22_lab_advanced/openstack/control.yml
@@ -17,6 +17,7 @@ classes:
 - system.galera.server.database.ceilometer
 - system.galera.server.database.cinder
 - system.galera.server.database.glance
+- system.galera.server.database.grafana
 - system.galera.server.database.heat
 - system.galera.server.database.keystone
 - system.galera.server.database.nova

--- a/classes/system/galera/server/database/grafana.yml
+++ b/classes/system/galera/server/database/grafana.yml
@@ -1,0 +1,16 @@
+parameters:
+  mysql:
+    server:
+      database:
+        grafana:
+          encoding: utf8
+          users:
+          - name: grafana
+            password: ${_param:mysql_grafana_password}
+            host: '%'
+            rights: all
+          - name: grafana
+            password: ${_param:mysql_grafana_password}
+            host: ${_param:cluster_local_address}
+            rights: all
+

--- a/classes/system/grafana/server/single.yml
+++ b/classes/system/grafana/server/single.yml
@@ -2,7 +2,6 @@ classes:
 - service.grafana.server.single
 parameters:
   _param:
-    postgresql_grafana_password: password
     grafana_port: 3000
     grafana_user: admin
     grafana_password: admin
@@ -20,7 +19,12 @@ parameters:
         address: ${_param:single_address}
         port: ${_param:grafana_port}
       database:
-        engine: sqlite3
+        engine: mysql
+        host: ${_param:openstack_control_address}
+        port: 3306
+        name: grafana
+        user: grafana
+        password: ${_param:mysql_grafana_password}
       auth:
         engine: basic
       admin:


### PR DESCRIPTION
This patch configures Grafana to use MySQL installed by OpenStack
instead of SQlite3. It configures the MySQL database with a new table
and a new user for Grafana and it configures Grafana to use the MySQL.