### PR TITLE
Add model for basic ceilometer installation

### DIFF
--- a/classes/cluster/mk22_ceilometer_lab/fuel/config.yml
+++ b/classes/cluster/mk22_ceilometer_lab/fuel/config.yml
@@ -1,0 +1,86 @@
+classes:
+- service.git.client
+- system.linux.system.single
+- system.linux.system.repo.tcp_salt
+- system.openssh.client.lab
+- system.salt.master.git
+- system.reclass.storage.salt
+- system.salt.minion.pki.authority
+- system.salt.minion.pki.certificate
+- system.sphinx.server.doc.reclass
+- system.keystone.client.single
+- system.mysql.client.single
+- system.reclass.storage.system.openstack_control_cluster
+- system.reclass.storage.system.openstack_compute_single
+- system.reclass.storage.system.openstack_dashboard_single
+- system.reclass.storage.system.monitoring_service_single
+- cluster.mk22_ceilometer_basic
+parameters:
+  _param:
+    salt_master_environment_repository: "https://github.com/tcpcloud"
+    salt_master_environment_revision: master
+    salt_master_base_environment: dev
+    reclass_data_repository: "git@github.com:ityaptin/mk-lab-salt-model.git"
+    reclass_data_revision: dash_new
+    reclass_config_master: 192.168.10.100
+    single_address: 172.16.10.100
+    salt_master_host: 127.0.0.1
+    salt_minion_ca_host: ${linux:network:fqdn}
+  linux:
+    network:
+      interface:
+        ens4:
+          enabled: true
+          type: eth
+          proto: dhcp
+  reclass:
+    storage:
+      node:
+        openstack_control_node01:
+          classes:
+          - service.galera.master.cluster
+          params:
+            mysql_cluster_role: master
+        openstack_control_node02:
+          classes:
+          - service.galera.slave.cluster
+          params:
+            mysql_cluster_role: slave
+        openstack_control_node03:
+          classes:
+          - service.galera.slave.cluster
+          params:
+            mysql_cluster_role: slave
+  salt:
+    master:
+      environment:
+        dev:
+          formula:
+            cinder:
+              revision: stacklight
+            collectd:
+              revision: stacklight
+            galera:
+              revision: stacklight
+            glance:
+              revision: stacklight
+            haproxy:
+              revision: stacklight
+            heat:
+              revision: stacklight
+            heka:
+              revision: stacklight
+            keystone:
+              revision: stacklight
+            linux:
+              revision: stacklight
+            memcached:
+              revision: stacklight
+            neutron:
+              revision: stacklight
+            nova:
+              revision: stacklight
+            ntp:
+              revision: stacklight
+            rabbitmq:
+              revision: stacklight

--- a/classes/cluster/mk22_ceilometer_lab/fuel/init.yml
+++ b/classes/cluster/mk22_ceilometer_lab/fuel/init.yml
@@ -1,0 +1,14 @@
+parameters:
+  linux:
+    network:
+      host:
+        cfg01:
+          address: ${_param:fuel_config_address}
+          names:
+          - cfg01
+          - cfg01.${_param:cluster_domain}
+        cfg:
+          address: ${_param:fuel_config_address}
+          names:
+          - cfg
+          - cfg.${_param:cluster_domain}

--- a/classes/cluster/mk22_ceilometer_lab/init.yml
+++ b/classes/cluster/mk22_ceilometer_lab/init.yml
@@ -1,0 +1,30 @@
+classes:
+- system.linux.system.single
+- cluster.mk22_ceilometer_basic.fuel
+- cluster.mk22_ceilometer_basic.monitoring
+- cluster.mk22_ceilometer_basic.openstack
+parameters:
+  _param:
+    cluster_domain: mk22-ceilometer-basic.local
+    cluster_name: mk22_ceilometer_basic
+    cluster_public_host: _
+    # fuel service addresses
+    fuel_config_address: 172.16.10.100
+    # openstack service addresses
+    openstack_proxy_address: 172.16.10.121
+    openstack_proxy_node01_address: 172.16.10.121
+    openstack_control_address: 172.16.10.254
+    openstack_control_node01_address: 172.16.10.101
+    openstack_control_node02_address: 172.16.10.102
+    openstack_control_node03_address: 172.16.10.103
+    # monitoring service addresses
+    monitoring_service_address: 172.16.10.107
+    monitoring_service_node01_address: 172.16.10.107
+  linux:
+    network:
+      host:
+        cmp01:
+          address: 172.16.10.105
+          names:
+          - cmp01
+          - cmp01.${_param:cluster_domain}

--- a/classes/cluster/mk22_ceilometer_lab/monitoring/client.yml
+++ b/classes/cluster/mk22_ceilometer_lab/monitoring/client.yml
@@ -1,0 +1,5 @@
+classes:
+- system.collectd.client.output.carbon
+- system.sensu.client.single
+- system.heka.shipper.single
+- cluster.mk22_ceilometer_basic

--- a/classes/cluster/mk22_ceilometer_lab/monitoring/init.yml
+++ b/classes/cluster/mk22_ceilometer_lab/monitoring/init.yml
@@ -1,0 +1,24 @@
+parameters:
+  _param:
+    carbon_message_queue_host: mon
+    carbon_message_queue_port: 2023
+    heka_elasticsearch_host: mon
+    heka_amqp_host: mon
+    heka_amqp_password: password
+    rabbitmq_graphite_password: password
+    rabbitmq_monitor_password: password
+    sensu_dashboard_password: password
+    stacklight_influxdb_password: r00tme
+  linux:
+    network:
+      host:
+        mon:
+          address: ${_param:monitoring_service_address}
+          names:
+          - mon
+          - mon.${_param:cluster_domain}
+        mon01:
+          address: ${_param:monitoring_service_node01_address}
+          names:
+          - mon01
+          - mon01.${_param:cluster_domain}

--- a/classes/cluster/mk22_ceilometer_lab/monitoring/proxy.yml
+++ b/classes/cluster/mk22_ceilometer_lab/monitoring/proxy.yml
@@ -1,0 +1,13 @@
+classes:
+- system.nginx.server.single
+- system.nginx.server.proxy.graphite_web
+- system.nginx.server.proxy.sensu_web
+- system.nginx.server.proxy.kibana_web
+- cluster.mk22_ceilometer_basic
+parameters:
+  _param:
+    nginx_proxy_ssl:
+      enabled: true
+      authority: mk_lab_ca
+      engine: salt
+      mode: secure

--- a/classes/cluster/mk22_ceilometer_lab/monitoring/server.yml
+++ b/classes/cluster/mk22_ceilometer_lab/monitoring/server.yml
@@ -1,0 +1,25 @@
+classes:
+- system.sensu.client.remote
+- system.sensu.server.single
+- system.sensu.server.handler.mail
+- system.sensu.server.dashboard
+- system.grafana.server.single
+- system.graphite.collector.single
+- system.graphite.server.single
+- system.heka.router.single
+- system.kibana.server.single
+- system.rabbitmq.server.vhost.monitoring
+- system.elasticsearch.server.single
+- system.influxdb.server.single
+- system.rabbitmq.server.single
+- cluster.mk22_ceilometer_basic
+parameters:
+  _param:
+    kibana_elasticsearch_host: localhost
+  linux:
+    network:
+      interface:
+        ens4:
+          enabled: true
+          type: eth
+          proto: dhcp

--- a/classes/cluster/mk22_ceilometer_lab/openstack/compute.yml
+++ b/classes/cluster/mk22_ceilometer_lab/openstack/compute.yml
@@ -1,0 +1,34 @@
+classes:
+- system.linux.system.repo.contrail
+- system.linux.system.repo.mos9
+- system.nova.compute.cluster
+- system.ceilometer.agent.cluster
+- system.opencontrail.compute.cluster
+- cluster.mk22_ceilometer_basic
+parameters:
+  _param:
+    opencontrail_compute_gateway: 172.16.10.1
+    opencontrail_compute_address: ${_param:single_address}
+    opencontrail_compute_iface: eth1
+  linux:
+    network:
+      interface:
+        eth1:
+          enabled: true
+          type: eth
+          proto: manual
+        vhost0:
+          enabled: true
+          type: eth
+          mtu: 1500
+          address: ${_param:single_address}
+          netmask: '255.255.255.0'
+          pre_up_cmds:
+          - /usr/lib/contrail/if-vhost0
+          use_interfaces:
+          - eth1
+  nova:
+    compute:
+      vncproxy_url: http://${_param:cluster_vip_address}:6080
+      notification:
+        driver: messagingv2

--- a/classes/cluster/mk22_ceilometer_lab/openstack/control.yml
+++ b/classes/cluster/mk22_ceilometer_lab/openstack/control.yml
@@ -1,0 +1,83 @@
+classes:
+- system.linux.system.lowmem
+- system.linux.system.repo.contrail
+- system.linux.system.repo.mos9
+- system.linux.system.repo.tcp_extra
+- system.memcached.server.single
+- system.rabbitmq.server.cluster
+- system.rabbitmq.server.vhost.openstack
+- system.keystone.server.cluster
+- system.glance.control.cluster
+- system.nova.control.cluster
+- system.neutron.control.cluster
+- system.cinder.control.cluster
+- system.heat.server.cluster
+- system.aodh.server.cluster
+- system.ceilometer.server.cluster
+- system.opencontrail.control.cluster
+- system.heka.os_telemetry_collector.single
+- system.galera.server.cluster
+- system.galera.server.database.aodh
+- system.galera.server.database.ceilometer
+- system.galera.server.database.cinder
+- system.galera.server.database.glance
+- system.galera.server.database.heat
+- system.galera.server.database.keystone
+- system.galera.server.database.nova
+- cluster.mk22_ceilometer_basic
+parameters:
+  _param:
+    keepalived_vip_interface: eth1
+  linux:
+    system:
+      package:
+        python-msgpack:
+          version: latest
+    network:
+      interface:
+        eth1:
+          enabled: true
+          type: eth
+          proto: dhcp
+  keepalived:
+    cluster:
+      instance:
+        VIP:
+          virtual_router_id: 150
+  keystone:
+    server:
+      admin_email: ${_param:admin_email}
+  glance:
+    server:
+      storage:
+        engine: file
+      images: []
+      workers: 1
+  nova:
+    controller:
+      networking: contrail
+      cpu_allocation: 54
+      bind:
+        private_address: ${_param:cluster_local_address}
+        public_address: ${_param:cluster_vip_address}
+        novncproxy_port: 6080
+      vncproxy_url: http://${_param:cluster_vip_address}:6080
+      cache:
+        engine: memcached
+        prefix: CACHE_NOVA
+        members:
+        - host: 127.0.0.1
+          port: 11211
+      workers: 1
+  neutron:
+    server:
+      plugin: contrail
+      tunnel_type: vxlan
+      public_networks: []
+      contrail:
+        version: ${_param:opencontrail_version}
+  cinder:
+    volume:
+      notification: true
+    controller:
+      notification: true

--- a/classes/cluster/mk22_ceilometer_lab/openstack/dashboard.yml
+++ b/classes/cluster/mk22_ceilometer_lab/openstack/dashboard.yml
@@ -1,0 +1,16 @@
+classes:
+- system.linux.system.repo.tcp_base
+- system.horizon.server.single
+- cluster.mk22_lab_basic_ceilometer
+parameters:
+  linux:
+    system:
+      repo:
+        tcpcloud_openstack:
+          source: deb [arch=amd64] http://apt.tcpcloud.eu/nightly/ trusty liberty
+    network:
+      interface:
+        eth1:
+          enabled: true
+          type: eth
+          proto: dhcp

--- a/classes/cluster/mk22_ceilometer_lab/openstack/init.yml
+++ b/classes/cluster/mk22_ceilometer_lab/openstack/init.yml
@@ -1,0 +1,108 @@
+parameters:
+  _param:
+    openstack_version: mitaka
+    openstack_region: RegionOne
+    admin_email: root@localhost
+    opencontrail_version: 3.0
+    opencontrail_compute_dns: 8.8.8.8
+    opencontrail_stats_password: contrail123
+    galera_server_cluster_name: openstack_cluster
+    galera_server_maintenance_password: workshop
+    galera_server_admin_password: workshop
+    cluster_vip_address: 172.16.10.254
+    cluster_local_address: ${_param:single_address}
+    cluster_node01_hostname: ctl01
+    cluster_node01_address: 172.16.10.101
+    cluster_node02_hostname: ctl02
+    cluster_node02_address: 172.16.10.102
+    cluster_node03_hostname: ctl03
+    cluster_node03_address: 172.16.10.103
+    rabbitmq_secret_key: workshop
+    rabbitmq_admin_password: workshop
+    rabbitmq_openstack_password: workshop
+    rabbitmq_cold_password: workshop
+    glance_version: ${_param:openstack_version}
+    glance_service_host: ${_param:cluster_vip_address}
+    keystone_version: ${_param:openstack_version}
+    keystone_service_host: ${_param:cluster_vip_address}
+    heat_version: ${_param:openstack_version}
+    heat_service_host: ${_param:cluster_vip_address}
+    heat_domain_admin_password: workshop
+    ceilometer_version: ${_param:openstack_version}
+    ceilometer_service_host: ${_param:cluster_vip_address}
+    aodh_version: ${_param:openstack_version}
+    aodh_service_host: ${_param:cluster_vip_address}
+    cinder_version: ${_param:openstack_version}
+    cinder_service_host: ${_param:cluster_vip_address}
+    ceilometer_graphite_publisher_host: 172.16.10.107
+    ceilometer_graphite_publisher_port: 2013
+    nova_version: ${_param:openstack_version}
+    nova_service_host: ${_param:cluster_vip_address}
+    nova_vncproxy_url: http://${_param:cluster_vip_address}:8060
+    neutron_version: ${_param:openstack_version}
+    neutron_service_host: ${_param:cluster_vip_address}
+    glusterfs_service_host: ${_param:cluster_vip_address}
+    mysql_admin_user: root
+    mysql_admin_password: workshop
+    mysql_aodh_password: workshop
+    mysql_cinder_password: workshop
+    mysql_ceilometer_password: workshop
+    mysql_glance_password: workshop
+    mysql_heat_password: workshop
+    mysql_keystone_password: workshop
+    mysql_neutron_password: workshop
+    mysql_nova_password: workshop
+    keystone_service_token: workshop
+    keystone_admin_password: workshop
+    keystone_aodh_password: workshop
+    keystone_ceilometer_password: workshop
+    keystone_cinder_password: workshop
+    keystone_glance_password: workshop
+    keystone_heat_password: workshop
+    keystone_keystone_password: workshop
+    keystone_neutron_password: workshop
+    keystone_nova_password: workshop
+    ceilometer_secret_key: workshop
+    stacklight_influxdb_password: r00tme
+    horizon_version: ${_param:openstack_version}
+    horizon_secret_key: opaesee8Que2yahJoh9fo0eefo1Aeyo6ahyei8zeiboh3aeth5loth7ieNa5xi5e
+    horizon_identity_host: ${_param:cluster_vip_address}
+    horizon_identity_encryption: none
+    horizon_identity_version: 3
+    mongodb_server_replica_set: ceilometer
+    mongodb_ceilometer_password: cloudlab
+    mongodb_admin_password: cloudlab
+    mongodb_shared_key: eoTh1AwahlahqueingeejooLughah4tei9feing0eeVaephooDi2li1TaeV1ooth
+  linux:
+    network:
+      host:
+        prx:
+          address: ${_param:openstack_proxy_address}
+          names:
+          - prx
+          - prx.${_param:cluster_domain}
+        prx01:
+          address: ${_param:openstack_proxy_node01_address}
+          names:
+          - prx01
+          - prx01.${_param:cluster_domain}
+        ctl:
+          address: ${_param:openstack_control_address}
+          names:
+          - ctl
+          - ctl.${_param:cluster_domain}
+        ctl01:
+          address: ${_param:openstack_control_node01_address}
+          names:
+          - ctl01
+          - ctl01.${_param:cluster_domain}
+        ctl02:
+          address: ${_param:openstack_control_node02_address}
+          names:
+          - ctl02
+          - ctl02.${_param:cluster_domain}
+        ctl03:
+          address: ${_param:openstack_control_node03_address}
+          names:
+          - ctl03
+          - ctl03.${_param:cluster_domain}

--- a/classes/cluster/mk22_ceilometer_lab/openstack/proxy.yml
+++ b/classes/cluster/mk22_ceilometer_lab/openstack/proxy.yml
@@ -1,0 +1,15 @@
+classes:
+- system.nginx.server.single
+- system.nginx.server.proxy.opencontrail_web
+- system.nginx.server.proxy.openstack_api
+- system.nginx.server.proxy.openstack_vnc
+- system.nginx.server.proxy.openstack_web
+- system.salt.minion.pki.certificate
+- cluster.mk22_ceilometer_basic
+parameters:
+  _param:
+    nginx_proxy_ssl:
+      enabled: true
+      authority: mk_lab_ca
+      engine: salt
+      mode: secure

--- a/nodes/control/cfg01.mk22-ceilometer-basic.local.yml
+++ b/nodes/control/cfg01.mk22-ceilometer-basic.local.yml
@@ -1,0 +1,11 @@
+classes:
+- cluster.mk22_ceilometer_basic.fuel.config
+- cluster.mk22_ceilometer_basic.openstack.proxy
+parameters:
+  _param:
+    linux_system_codename: xenial
+    reclass_data_revision: dash
+  linux:
+    system:
+      name: cfg01
+      domain: mk22-ceilometer-basic.local


### PR DESCRIPTION
Model mk22_ceilometer_lab is a fork of mk22_lab_basic that contains
classes and parameters for Mitaka Ceilometer, Aodh and
os_telemetry_collector installation.