### PR TITLE
Move StackLight client classes to the config node

### DIFF
--- a/classes/cluster/mk20_stacklight_advanced/fuel/config.yml
+++ b/classes/cluster/mk20_stacklight_advanced/fuel/config.yml
@@ -11,6 +11,9 @@ classes:
 - system.keystone.client.single
 - system.keystone.client.service.nova
 - system.mysql.client.single
+- system.elasticsearch.client.single
+- system.grafana.client.single
+- system.kibana.client.single
 - system.reclass.storage.system.openstack_control_cluster
 - system.reclass.storage.system.openstack_compute_single
 - system.reclass.storage.system.openstack_dashboard_single

--- a/classes/cluster/mk20_stacklight_basic/fuel/config.yml
+++ b/classes/cluster/mk20_stacklight_basic/fuel/config.yml
@@ -11,6 +11,9 @@ classes:
 - system.keystone.client.single
 - system.keystone.client.service.nova
 - system.mysql.client.single
+- system.elasticsearch.client.single
+- system.grafana.client.single
+- system.kibana.client.single
 - system.reclass.storage.system.openstack_control_cluster
 - system.reclass.storage.system.openstack_compute_single
 - system.reclass.storage.system.openstack_dashboard_single

--- a/classes/cluster/mk22_lab_advanced/fuel/config.yml
+++ b/classes/cluster/mk22_lab_advanced/fuel/config.yml
@@ -11,6 +11,9 @@ classes:
 - system.keystone.client.single
 - system.keystone.client.service.nova21
 - system.mysql.client.single
+- system.elasticsearch.client.single
+- system.grafana.client.single
+- system.kibana.client.single
 - system.reclass.storage.system.openstack_control_cluster
 - system.reclass.storage.system.openstack_compute_single
 - system.reclass.storage.system.openstack_dashboard_single

--- a/classes/system/reclass/storage/system/stacklight_server_cluster.yml
+++ b/classes/system/reclass/storage/system/stacklight_server_cluster.yml
@@ -8,9 +8,6 @@ parameters:
           classes:
           - cluster.${_param:cluster_name}.stacklight.server
           - system.influxdb.server.single
-          - system.elasticsearch.client.single
-          - system.grafana.client.single
-          - system.kibana.client.single
           params:
             salt_master_host: ${_param:reclass_config_master}
             linux_system_codename: xenial

--- a/classes/system/reclass/storage/system/stacklight_server_single.yml
+++ b/classes/system/reclass/storage/system/stacklight_server_single.yml
@@ -7,8 +7,6 @@ parameters:
           domain: ${_param:cluster_domain}
           classes:
           - cluster.${_param:cluster_name}.stacklight.server
-          - system.elasticsearch.client.single
-          - system.grafana.client.single
           params:
             salt_master_host: ${_param:reclass_config_master}
             linux_system_codename: xenial


### PR DESCRIPTION
This is to be consistent with keystone.client et al.