### PR TITLE
Enable checks for haproxy glance_registry_api

### DIFF
--- a/classes/system/glance/control/cluster.yml
+++ b/classes/system/glance/control/cluster.yml
@@ -37,7 +37,6 @@ parameters:
         glance_registry_api:
           type: general-service
           service_name: glance
-          check: false
           binds:
           - address: ${_param:cluster_vip_address}
             port: 9191


### PR DESCRIPTION
Checks are currently disabled for glance_registry_api in the HAProxy configuration. This enables them.