### PR TITLE
Fix Nginx proxy for Nagios UI port

### DIFF
--- a/classes/cluster/mk20_stacklight_advanced/stacklight/proxy.yml
+++ b/classes/cluster/mk20_stacklight_advanced/stacklight/proxy.yml
@@ -2,6 +2,7 @@ classes:
 - system.nginx.server.single
 - system.nginx.server.proxy.grafana_web
 - system.nginx.server.proxy.kibana_web
+- system.nginx.server.proxy.nagios_web
 - system.salt.minion.pki.certificate
 - cluster.mk20_stacklight_advanced
 parameters:

--- a/classes/cluster/mk20_stacklight_basic/stacklight/proxy.yml
+++ b/classes/cluster/mk20_stacklight_basic/stacklight/proxy.yml
@@ -1,6 +1,7 @@
 classes:
 - system.nginx.server.proxy.grafana_web
 - system.nginx.server.proxy.kibana_web
+- system.nginx.server.proxy.nagios_web
 - system.salt.minion.pki.certificate
 - cluster.mk20_stacklight_basic
 parameters:

--- a/classes/system/nginx/server/proxy/nagios_web.yml
+++ b/classes/system/nginx/server/proxy/nagios_web.yml
@@ -8,8 +8,8 @@ parameters:
           type: nginx_proxy
           name: nagios
           proxy:
-            host: mon01
-            port: 8001
+            host: ${_param:stacklight_monitor_address}
+            port: 80
             protocol: http
           host:
             name: ${_param:cluster_public_host}


### PR DESCRIPTION
The port 8001 is used internaly by collectors/aggregator to push statuses.