### PR TITLE
Rework the StackLight deploy scripts

### DIFF
--- a/scripts/bootstrap_all.sh
+++ b/scripts/bootstrap_all.sh
@@ -5,6 +5,6 @@
 ./openstack_infra_install.sh
 ./openstack_control_install.sh
 ./opencontrail_control_install.sh
-./stacklight_monitor_install.sh
-./openstack_compute_install.sh
 ./stacklight_infra_install.sh
+./openstack_compute_install.sh
+./stacklight_monitor_install.sh

--- a/scripts/stacklight_infra_install.sh
+++ b/scripts/stacklight_infra_install.sh
@@ -1,31 +1,11 @@
 #!/bin/bash -x
 exec > >(tee -i /tmp/$(basename $0 .sh)_$(date '+%Y-%m-%d_%H-%M-%S').log) 2>&1
 
-# Install StackLight collectors
-salt "*" state.sls collectd
-salt "*" state.sls heka
-
-# Update salt-mine metadata definitions
-salt "*" state.sls salt.minion.grains
-salt "*" mine.flush
-salt "*" saltutil.refresh_modules
-salt "*" mine.update
-
-sleep 5
-
-# Update monitoring node with mine metadata
-salt -C 'I@heka:aggregator' state.sls collectd,heka
-# Start manually the services that are bound to the monitoring VIP
-salt -G 'ipv4:172.16.10.253' service.start remote_collectd
-salt -G 'ipv4:172.16.10.253' service.start remote_collector
-salt -G 'ipv4:172.16.10.253' service.start aggregator
-
-
-# Install Nagios once alarms are stored in Salt Mine
-salt -C 'I@nagios:server' state.sls nagios
-
-# The following is only applied when Nagios is deployed in cluster:
-# stop Nagios on monitoring nodes (b/c package starts it by default),
-# then start Nagios where the VIP is running
-salt -C 'I@nagios:server:automatic_starting:False' service.stop nagios3
-salt -G 'ipv4:172.16.10.253' service.start nagios3
+# Install the StackLight backends
+salt -C 'I@elasticsearch:server' state.sls elasticsearch.server -b 1
+salt -C 'I@influxdb:server' state.sls influxdb -b 1
+salt -C 'I@kibana:server' state.sls kibana.server -b 1
+salt -C 'I@grafana:server' state.sls grafana.server -b 1
+salt -C 'I@nagios:server' state.sls nagios -b 1
+salt -C 'I@elasticsearch:client' state.sls elasticsearch.client
+salt -C 'I@kibana:client' state.sls kibana.client

--- a/scripts/stacklight_monitor_install.sh
+++ b/scripts/stacklight_monitor_install.sh
@@ -1,21 +1,37 @@
 #!/bin/bash -x
 exec > >(tee -i /tmp/$(basename $0 .sh)_$(date '+%Y-%m-%d_%H-%M-%S').log) 2>&1
 
-# StackLight services
-salt -C 'I@elasticsearch:server' state.sls elasticsearch.server -b 1
-salt -C 'I@influxdb:server' state.sls influxdb -b 1
-salt -C 'I@kibana:server' state.sls kibana.server
-salt -C 'I@grafana:server' state.sls grafana.server -b 1
-
-# Gather Grafana dashboards from all nodes
-salt -C 'I@grafana:collector' state.sls grafana.collector
-salt "*" state.sls salt.minion.grains
+# Start by flusing Salt Mine to make sure it is clean
 salt "*" mine.flush
+
+# Install StackLight services, and gather the Collectd and Heka metadata
+salt "*" state.sls collectd
+salt "*" state.sls heka
+
+# Gather the Grafana metadata as grains
+salt -C 'I@grafana:collector' state.sls grafana.collector
+
+# Update Salt Mine
+salt "*" state.sls salt.minion.grains
 salt "*" saltutil.refresh_modules
 salt "*" mine.update
 
 sleep 5
 
-salt -C 'I@kibana:client' state.sls kibana.client
+# Update Heka
+salt -C 'I@heka:aggregator:enabled:True or I@heka:remote_collector:enabled:True' state.sls heka
+
+# Update Collectd
+salt -C 'I@collectd:remote_client:enabled:True' state.sls collectd
+
+# Update Nagios
+salt -C 'I@nagios:server' state.sls nagios
+
+# The following is only applied when Nagios is deployed in cluster: stop Nagios
+# on monitoring nodes (b/c package starts it by default), then start Nagios
+# where the VIP is running
+salt -C 'I@nagios:server:automatic_starting:False' service.stop nagios3
+salt -G 'ipv4:172.16.10.253' service.start nagios3
+
+# Finalize the configuration of Grafana (add the dashboards...)
 salt -C 'I@grafana:client' state.sls grafana.client
-salt -C 'I@elasticsearch:client' state.sls elasticsearch.client


### PR DESCRIPTION
This commit changes the StackLight deploy scripts, stacklight_infra_install.sh and stacklight_monitor_install.sh.

stacklight_infra_install.sh now just takes care of the backends/infrastructure, installing Elasticsearch, Kibana, InfluxDB and Grafana on the monitoring nodes.

stacklight_monitor_install.sh finalizes the installation of StackLight, deploying the Collectd and Heka agents and configuring them based on the metadata in Salt Mine.

The stacklight_monitor_install.sh can be run at will. In particular the script can be run after changing the monitoring configuration. It will take care of updating the metadata in Salt Mine and re-configuring the
StackLight agents as appropriate.