### PR TITLE
Fix InfluxDB deployment for mk22_lab_advanced

### DIFF
--- a/classes/cluster/mk22_lab_advanced/stacklight/server.yml
+++ b/classes/cluster/mk22_lab_advanced/stacklight/server.yml
@@ -4,7 +4,6 @@ classes:
 - system.heka.aggregator.cluster
 - system.elasticsearch.server.cluster
 - system.elasticsearch.server.curator
-- system.influxdb.server.cluster
 - system.kibana.server.single
 - system.grafana.server.single
 - cluster.mk22_lab_advanced


### PR DESCRIPTION
InfluxDB is deployed only on the mon01 node.