### PR TITLE
Add some enhacements

### DIFF
--- a/scripts/bootstrap_all.sh
+++ b/scripts/bootstrap_all.sh
@@ -1,10 +1,19 @@
 #!/bin/bash -x
 
-./fuel_config_verify.sh
-./fuel_infra_install.sh
-./openstack_infra_install.sh
-./openstack_control_install.sh
-./opencontrail_control_install.sh
-./stacklight_infra_install.sh
-./openstack_compute_install.sh
-./stacklight_monitor_install.sh
+CWD=`dirname $0`
+CWD=`(cd $CWD ; pwd)`
+
+SALT_OPTS=${SALT_OPTS:-"--state-output=changes --state-verbose=False"}
+SSH_OPTS=${SSH_OPTS:-"-o StrictHostKeyChecking=no"}
+
+export SALT_OPTS
+export SSH_OPTS
+
+$CWD/fuel_config_verify.sh
+$CWD/fuel_infra_install.sh
+$CWD/openstack_infra_install.sh
+$CWD/openstack_control_install.sh
+$CWD/opencontrail_control_install.sh
+$CWD/stacklight_infra_install.sh
+$CWD/openstack_compute_install.sh
+$CWD/stacklight_monitor_install.sh

--- a/scripts/fuel_config_verify.sh
+++ b/scripts/fuel_config_verify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 exec > >(tee -i /tmp/$(basename $0 .sh)_$(date '+%Y-%m-%d_%H-%M-%S').log) 2>&1
 
 # Verify that Salt master is correctly bootstrapped
@@ -8,3 +8,25 @@ reclass-salt --top
 # Verify that Salt minions are responding and the same version as master
 salt-call --version
 salt '*' test.version
+
+# Get list of hostnames in current deployment
+hosts=(`salt-call pillar.get linux:network:host | egrep '0.*:' | sed -e 's/  *//' -e 's/://'`)
+wanted=${#hosts[@]}
+
+# Default max waiting time is 5mn
+MAX_WAIT=${MAX_WAIT:-300}
+while [ true ]; do
+	nb_nodes=`salt '*' test.ping | egrep ':$' | wc -l`
+	if [ -n "$nb_nodes" ] && [ $nb_nodes -eq $wanted ]; then
+		echo "All nodes are now answering to salt pings"
+		break
+	fi
+	MAX_WAIT=`expr $MAX_WAIT - 15`
+	if [ $MAX_WAIT -le 0 ]; then
+		echo "Only $nb_nodes answering to salt pings out of $wanted after maximum timeout"
+		exit 1
+	fi
+	echo -n "Only $nb_nodes answering to salt pings out of $wanted. Waiting a bit longer ..."
+	sleep 15
+	echo
+done

--- a/scripts/fuel_infra_install.sh
+++ b/scripts/fuel_infra_install.sh
@@ -2,15 +2,15 @@
 exec > >(tee -i /tmp/$(basename $0 .sh)_$(date '+%Y-%m-%d_%H-%M-%S').log) 2>&1
 
 # Refresh salt master config
-salt -C 'I@salt:master' state.sls salt.master,reclass
+salt $SALT_OPTS -C 'I@salt:master' state.sls salt.master,reclass
 
 # Refresh minion's pillar data
-salt '*' saltutil.refresh_pillar
+salt $SALT_OPTS '*' saltutil.refresh_pillar
 
 # Sync all salt resources
-salt '*' saltutil.sync_all
+salt $SALT_OPTS '*' saltutil.sync_all
 
 sleep 5
 
 # Bootstrap all nodes
-salt "*" state.sls linux,openssh,salt.minion,ntp
+salt $SALT_OPTS "*" state.sls linux,openssh,salt.minion,ntp

--- a/scripts/opencontrail_control_install.sh
+++ b/scripts/opencontrail_control_install.sh
@@ -2,15 +2,20 @@
 exec > >(tee -i /tmp/$(basename $0 .sh)_$(date '+%Y-%m-%d_%H-%M-%S').log) 2>&1
 
 # Install opencontrail database services
-salt -C 'I@opencontrail:database' state.sls opencontrail.database -b 1
+salt $SALT_OPTS -C 'I@opencontrail:database' state.sls opencontrail.database -b 1
 # Install opencontrail control services
-salt -C 'I@opencontrail:control' state.sls opencontrail -b 1
+salt $SALT_OPTS -C 'I@opencontrail:control' state.sls opencontrail -b 1
 
 # Provision opencontrail control services
-salt -C 'I@opencontrail:control:id:1' cmd.run "/usr/share/contrail-utils/provision_control.py --api_server_ip 172.16.10.254 --api_server_port 8082 --host_name ctl01 --host_ip 172.16.10.101 --router_asn 64512 --admin_password workshop --admin_user admin --admin_tenant_name admin --oper add"
-salt -C 'I@opencontrail:control:id:1' cmd.run "/usr/share/contrail-utils/provision_control.py --api_server_ip 172.16.10.254 --api_server_port 8082 --host_name ctl02 --host_ip 172.16.10.102 --router_asn 64512 --admin_password workshop --admin_user admin --admin_tenant_name admin --oper add"
-salt -C 'I@opencontrail:control:id:1' cmd.run "/usr/share/contrail-utils/provision_control.py --api_server_ip 172.16.10.254 --api_server_port 8082 --host_name ctl03 --host_ip 172.16.10.103 --router_asn 64512 --admin_password workshop --admin_user admin --admin_tenant_name admin --oper add"
+hosts=(`salt-call pillar.get linux:network:host | egrep 'ctl0.*:' | sed -e 's/  *//' -e 's/://'`)
+vip=`salt-call pillar.get _param:cluster_vip_address | grep '^ ' | sed -e 's/  *//'`
+nb=`expr ${#hosts[@]} - 1`
+for i in $(seq 0 $nb); do
+	h=${hosts[$i]}
+	ip=`salt-call pillar.get linux:network:host:${h}:address | grep '^ ' | sed -e 's/  *//'`
+	salt $SALT_OPTS -C 'I@opencontrail:control:id:1' cmd.run "/usr/share/contrail-utils/provision_control.py --api_server_ip $vip --api_server_port 8082 --host_name $h --host_ip $ip --router_asn 64512 --admin_password workshop --admin_user admin --admin_tenant_name admin --oper add"
+done
 
 # Test opencontrail
-salt -C 'I@opencontrail:control' cmd.run "contrail-status"
-salt -C 'I@keystone:server' cmd.run ". /root/keystonerc; neutron net-list; nova net-list"
+salt $SALT_OPTS -C 'I@opencontrail:control' cmd.run "contrail-status"
+salt $SALT_OPTS -C 'I@keystone:server' cmd.run ". /root/keystonerc; neutron net-list; nova net-list"

--- a/scripts/openstack_compute_install.sh
+++ b/scripts/openstack_compute_install.sh
@@ -2,13 +2,32 @@
 exec > >(tee -i /tmp/$(basename $0 .sh)_$(date '+%Y-%m-%d_%H-%M-%S').log) 2>&1
 
 # Configure compute nodes
-salt "cmp*" state.apply
-salt "cmp*" state.apply
+salt $SALT_OPTS "cmp*" state.apply
+salt $SALT_OPTS "cmp*" state.apply
+
+# Create subnet
+salt $SALT_OPTS 'ctl01*' cmd.run ". /root/keystonerc; neutron net-create net1; neutron subnet-create --name subnet1 net1 192.168.32.0/24 ; neutron net-list"
 
 # Provision opencontrail virtual routers
-salt -C 'I@opencontrail:control:id:1' cmd.run "/usr/share/contrail-utils/provision_vrouter.py --host_name cmp01 --host_ip 172.16.10.105 --api_server_ip 172.16.10.254 --oper add --admin_user admin --admin_password workshop --admin_tenant_name admin"
+hosts=(`salt-call pillar.get linux:network:host | egrep 'cmp0.*:' | sed -e 's/  *//' -e 's/://'`)
+vip=`salt-call pillar.get _param:cluster_vip_address | grep '^ ' | sed -e 's/  *//'`
+nb=`expr ${#hosts[@]} - 1`
+for i in $(seq 0 $nb); do
+	h=${hosts[$i]}
+	ip=`salt-call pillar.get linux:network:host:${h}:address | grep '^ ' | sed -e 's/  *//'`
+	salt $SALT_OPTS -C 'I@opencontrail:control:id:1' cmd.run "/usr/share/contrail-utils/provision_vrouter.py --host_name $h --host_ip $ip --api_server_ip $vip --oper add --admin_user admin --admin_password workshop --admin_tenant_name admin"
+done
+salt $SALT_OPTS 'cmp*' cmd.run "ip link set up eth1"﻿⁠⁠⁠⁠
 
 # Reboot compute nodes
-salt "cmp*" system.reboot
+salt $SALT_OPTS "cmp*" system.reboot
 
-sleep 30
+while true; do
+	salt $SALT_OPTS '*' test.ping | grep -q Minion
+	if [ $? -ne 0 ]; then
+		break
+	fi
+	echo -n "Waiting for compute nodes to answer salt pings ..."
+	sleep 10
+	echo
+done

--- a/scripts/openstack_control_install.sh
+++ b/scripts/openstack_control_install.sh
@@ -2,36 +2,38 @@
 exec > >(tee -i /tmp/$(basename $0 .sh)_$(date '+%Y-%m-%d_%H-%M-%S').log) 2>&1
 
 # setup keystone service
-salt -C 'I@keystone:server' state.sls keystone.server -b 1
+salt $SALT_OPTS -C 'I@keystone:server' state.sls keystone.server -b 1
 # populate keystone services/tenants/admins
-salt -C 'I@keystone:client' state.sls keystone.client
-salt -C 'I@keystone:server' cmd.run ". /root/keystonerc; keystone service-list"
+salt $SALT_OPTS -C 'I@keystone:client' state.sls keystone.client
+salt $SALT_OPTS -C 'I@keystone:server' cmd.run ". /root/keystonerc; keystone service-list"
 
 # Install glance and ensure glusterfs clusters
-salt -C 'I@glance:server' state.sls glance -b 1
-salt -C 'I@glance:server' state.sls glusterfs.client
+salt $SALT_OPTS -C 'I@glance:server' state.sls glance -b 1
+salt $SALT_OPTS -C 'I@glance:server' state.sls glusterfs.client
 # Update fernet tokens before doing request on keystone server. Otherwise
 # you will get an error like:
 # "No encryption keys found; run keystone-manage fernet_setup to bootstrap one"
-salt -C 'I@keystone:server' state.sls keystone.server
-salt -C 'I@keystone:server' cmd.run ". /root/keystonerc; glance image-list"
+salt $SALT_OPTS -C 'I@keystone:server' state.sls keystone.server
+# Install Cirros image
+ssh $SSH_OPTS ctl01 "source keystonerc; wget --progress=bar:force http://download.cirros-cloud.net/0.3.4/cirros-0.3.4-i386-disk.img ; glance image-create --name cirros --visibility public --disk-format qcow2 --container-format bare --progress < /root/cirros-0.3.4-i386-disk.img"
+salt $SALT_OPTS -C 'I@keystone:server' cmd.run ". /root/keystonerc; glance image-list"
 
 # Install nova service
-salt -C 'I@nova:controller' state.sls nova -b 1
-salt -C 'I@keystone:server' cmd.run ". /root/keystonerc; nova service-list"
+salt $SALT_OPTS -C 'I@nova:controller' state.sls nova -b 1
+salt $SALT_OPTS -C 'I@keystone:server' cmd.run ". /root/keystonerc; nova service-list"
 
 # Install cinder service
-salt -C 'I@cinder:controller' state.sls cinder -b 1
-salt -C 'I@keystone:server' cmd.run ". /root/keystonerc; cinder list"
+salt $SALT_OPTS -C 'I@cinder:controller' state.sls cinder -b 1
+salt $SALT_OPTS -C 'I@keystone:server' cmd.run ". /root/keystonerc; cinder list"
 
 # Install neutron service
-salt -C 'I@neutron:server' state.sls neutron -b 1
-salt -C 'I@keystone:server' cmd.run ". /root/keystonerc; neutron agent-list"
+salt $SALT_OPTS -C 'I@neutron:server' state.sls neutron -b 1
+salt $SALT_OPTS -C 'I@keystone:server' cmd.run ". /root/keystonerc; neutron agent-list ; neutron net-list ; nova net-list"
 
 # Install heat service
-salt -C 'I@heat:server' state.sls heat -b 1
-salt -C 'I@keystone:server' cmd.run ". /root/keystonerc; heat resource-type-list"
+salt $SALT_OPTS -C 'I@heat:server' state.sls heat -b 1
+salt $SALT_OPTS -C 'I@keystone:server' cmd.run ". /root/keystonerc; heat resource-type-list"
 
 # Install horizon dashboard
-salt -C 'I@horizon:server' state.sls horizon
-salt -C 'I@nginx:server' state.sls nginx
+salt $SALT_OPTS -C 'I@horizon:server' state.sls horizon
+salt $SALT_OPTS -C 'I@nginx:server' state.sls nginx

--- a/scripts/openstack_infra_install.sh
+++ b/scripts/openstack_infra_install.sh
@@ -2,32 +2,33 @@
 exec > >(tee -i /tmp/$(basename $0 .sh)_$(date '+%Y-%m-%d_%H-%M-%S').log) 2>&1
 
 # Install keepaliveds
-salt -C 'I@keepalived:cluster' state.sls keepalived -b 1
+salt $SALT_OPTS -C 'I@keepalived:cluster' state.sls keepalived -b 1
 # Check the VIPs
-salt -C 'I@keepalived:cluster' cmd.run "ip a | grep 172.16.10.2"
+salt $SALT_OPTS -C 'I@keepalived:cluster' cmd.run "ip a | grep 172.16.10.2"
 
 # Install gluster
-salt -C 'I@glusterfs:server' state.sls glusterfs.server.service
-salt -C 'I@glusterfs:server' state.sls glusterfs.server.setup -b 1
+salt $SALT_OPTS -C 'I@glusterfs:server' state.sls glusterfs.server.service
+salt $SALT_OPTS -C 'I@glusterfs:server' state.sls glusterfs.server.setup -b 1
 # Check the gluster status
-salt -C 'I@glusterfs:server' cmd.run "gluster peer status; gluster volume status" -b 1
+salt $SALT_OPTS -C 'I@glusterfs:server' cmd.run "gluster peer status; gluster volume status" -b 1
 
 # Install rabbitmq
-salt -C 'I@rabbitmq:server' state.sls rabbitmq
+salt $SALT_OPTS -C 'I@rabbitmq:server' state.sls rabbitmq
 # Check the rabbitmq status
-salt -C 'I@rabbitmq:server' cmd.run "rabbitmqctl cluster_status"
+salt $SALT_OPTS -C 'I@rabbitmq:server' cmd.run "rabbitmqctl cluster_status"
 
 # Install galera
-salt -C 'I@galera:master' state.sls galera
-salt -C 'I@galera:slave' state.sls galera
+salt $SALT_OPTS -C 'I@galera:master' state.sls galera
+salt $SALT_OPTS -C 'I@galera:slave' state.sls galera
 # Check galera status
-salt -C 'I@galera:master' mysql.status | grep -A1 wsrep_cluster_size
-salt -C 'I@galera:slave' mysql.status | grep -A1 wsrep_cluster_size
+salt $SALT_OPTS -C 'I@galera:master' mysql.status | egrep -A1 'wsrep_cluster_size|addresses'
+salt $SALT_OPTS -C 'I@galera:slave' mysql.status | egrep -A1 'wsrep_cluster_size|addresses'
 
 # Install haproxy
-salt -C 'I@haproxy:proxy' state.sls haproxy
-salt -C 'I@haproxy:proxy' service.status haproxy
-salt -I 'haproxy:proxy' service.restart rsyslog
+salt $SALT_OPTS -C 'I@haproxy:proxy' state.sls haproxy
+salt $SALT_OPTS -C 'I@haproxy:proxy' service.status haproxy
+salt $SALT_OPTS -I 'haproxy:proxy' service.restart rsyslog
 
 # Install memcached
-salt -C 'I@memcached:server' state.sls memcached
+salt $SALT_OPTS -C 'I@memcached:server' state.sls memcached
+salt $SALT_OPTS -C 'I@memcached:server' service.status memcached

--- a/scripts/stacklight_infra_install.sh
+++ b/scripts/stacklight_infra_install.sh
@@ -2,10 +2,10 @@
 exec > >(tee -i /tmp/$(basename $0 .sh)_$(date '+%Y-%m-%d_%H-%M-%S').log) 2>&1
 
 # Install the StackLight backends
-salt -C 'I@elasticsearch:server' state.sls elasticsearch.server -b 1
-salt -C 'I@influxdb:server' state.sls influxdb -b 1
-salt -C 'I@kibana:server' state.sls kibana.server -b 1
-salt -C 'I@grafana:server' state.sls grafana.server -b 1
-salt -C 'I@nagios:server' state.sls nagios -b 1
-salt -C 'I@elasticsearch:client' state.sls elasticsearch.client
-salt -C 'I@kibana:client' state.sls kibana.client
+salt $SALT_OPTS -C 'I@elasticsearch:server' state.sls elasticsearch.server -b 1
+salt $SALT_OPTS -C 'I@influxdb:server' state.sls influxdb -b 1
+salt $SALT_OPTS -C 'I@kibana:server' state.sls kibana.server -b 1
+salt $SALT_OPTS -C 'I@grafana:server' state.sls grafana.server -b 1
+salt $SALT_OPTS -C 'I@nagios:server' state.sls nagios -b 1
+salt $SALT_OPTS -C 'I@elasticsearch:client' state.sls elasticsearch.client
+salt $SALT_OPTS -C 'I@kibana:client' state.sls kibana.client

--- a/scripts/stacklight_monitor_install.sh
+++ b/scripts/stacklight_monitor_install.sh
@@ -2,33 +2,33 @@
 exec > >(tee -i /tmp/$(basename $0 .sh)_$(date '+%Y-%m-%d_%H-%M-%S').log) 2>&1
 
 # Start by flusing Salt Mine to make sure it is clean
-salt "*" mine.flush
+salt $SALT_OPTS "*" mine.flush
 
 # Install StackLight services, and gather the Collectd and Heka metadata
-salt "*" state.sls collectd
-salt "*" state.sls heka
+salt $SALT_OPTS "*" state.sls collectd
+salt $SALT_OPTS "*" state.sls heka
 
 # Gather the Grafana metadata as grains
-salt -C 'I@grafana:collector' state.sls grafana.collector
+salt $SALT_OPTS -C 'I@grafana:collector' state.sls grafana.collector
 
 # Update Salt Mine
-salt "*" state.sls salt.minion.grains
-salt "*" saltutil.refresh_modules
-salt "*" mine.update
+salt $SALT_OPTS "*" state.sls salt.minion.grains
+salt $SALT_OPTS "*" saltutil.refresh_modules
+salt $SALT_OPTS "*" mine.update
 
 sleep 5
 
 # Update Heka
-salt -C 'I@heka:aggregator:enabled:True or I@heka:remote_collector:enabled:True' state.sls heka
+salt $SALT_OPTS -C 'I@heka:aggregator:enabled:True or I@heka:remote_collector:enabled:True' state.sls heka
 
 # Update Collectd
-salt -C 'I@collectd:remote_client:enabled:True' state.sls collectd
+salt $SALT_OPTS -C 'I@collectd:remote_client:enabled:True' state.sls collectd
 
 # Update Nagios
-salt -C 'I@nagios:server' state.sls nagios
+salt $SALT_OPTS -C 'I@nagios:server' state.sls nagios
 
 # Finalize the configuration of Grafana (add the dashboards...)
-salt -C 'I@grafana:client' state.sls grafana.client
+salt $SALT_OPTS -C 'I@grafana:client' state.sls grafana.client
 
 # The following is only applied when StackLight is deployed in cluster
 # Get the StackLight VIP
@@ -36,11 +36,11 @@ vip=$(salt-call pillar.data _param:stacklight_monitor_address --out key|grep _pa
 vip=${vip:=172.16.10.253}
 
 # Start manually the services that are bound to the monitoring VIP
-salt -G "ipv4:$vip" service.start remote_collectd
-salt -G "ipv4:$vip" service.start remote_collector
-salt -G "ipv4:$vip" service.start aggregator
+salt $SALT_OPTS -G "ipv4:$vip" service.start remote_collectd
+salt $SALT_OPTS -G "ipv4:$vip" service.start remote_collector
+salt $SALT_OPTS -G "ipv4:$vip" service.start aggregator
 
 # Stop Nagios on monitoring nodes (b/c package starts it by default), then
 # start Nagios where the VIP is running.
-salt -C 'I@nagios:server:automatic_starting:False' service.stop nagios3
-salt -G "ipv4:$vip" service.start nagios3
+salt $SALT_OPTS -C 'I@nagios:server:automatic_starting:False' service.stop nagios3
+salt $SALT_OPTS -G "ipv4:$vip" service.start nagios3


### PR DESCRIPTION
Main script can be called from anywhere
Added some less verbose salt output options
  which can be customized from the command line
Added wait loop to prevent running into early
  errors when environment has just been bootstrapped
  from heat templates and nodes not all available
Added wait loop for compute reboot availability
Removed some harcoded IP values and hosts names
Added fix for compute interface availability