### PR TITLE
Disable collectd syslog logging

### DIFF
--- a/classes/system/collectd/client/output/heka.yml
+++ b/classes/system/collectd/client/output/heka.yml
@@ -14,3 +14,4 @@ parameters:
           port: ${_param:collectd_metric_collector_port}
       read_interval: 10
       use_fqdn: false
+      syslog_logging: false

--- a/classes/system/collectd/remote_client/output/heka.yml
+++ b/classes/system/collectd/remote_client/output/heka.yml
@@ -12,3 +12,4 @@ parameters:
           timeout: 5
       read_interval: 10
       use_fqdn: false
+      syslog_logging: false


### PR DESCRIPTION
Currently the `collectd` process logs both to `/var/log/collectd.log` file (through the `logfile` plugin) and to Syslog. This patch disables the logging to Syslog.