### PR TITLE
Rework metadata hierarchy for authentication parameters

### DIFF
--- a/classes/system/nagios/server/init.yml
+++ b/classes/system/nagios/server/init.yml
@@ -23,9 +23,10 @@ parameters:
       ui:
         enabled: true
         port: ${_param:nagios_ui_port}
-        basic_auth:
-          username: ${_param:nagios_username}
-          password: ${_param:nagios_password}
+        auth:
+          basic:
+            username: ${_param:nagios_username}
+            password: ${_param:nagios_password}
         wsgi:
           port: ${_param:nagios_status_port}
       notification:


### PR DESCRIPTION
Since LDAP authentication is supported, it makes sense to have a common
key 'host'.