### PR TITLE
Change names of couple ceilometer related configs to actual in sysclasses 

### DIFF
--- a/classes/system/ceilometer/server/cluster.yml
+++ b/classes/system/ceilometer/server/cluster.yml
@@ -7,12 +7,12 @@ parameters:
     server:
       database:
         influxdb:
-          host: ${_param:monitoring_service_address}
+          host: ${_param:stacklight_monitor_node01_address}
           port: 8086
           user: ceilometer
           password: ${_param:stacklight_influxdb_password}
           database: ceilometer
         elasticsearch:
           enabled: true
-          host: ${_param:monitoring_service_address}
+          host: ${_param:stacklight_monitor_address}
           port: 9200

--- a/classes/system/ceilometer/server/single.yml
+++ b/classes/system/ceilometer/server/single.yml
@@ -5,12 +5,12 @@ parameters:
     server:
       database:
         influxdb:
-          host: ${_param:monitoring_service_address}
+          host: ${_param:stacklight_monitor_node01_address}
           port: 8086
           user: ceilometer
           password: ${_param:stacklight_influxdb_password}
           database: ceilometer
         elasticsearch:
           enabled: true
-          host: ${_param:monitoring_service_address}
+          host: ${_param:stacklight_monitor_address}
           port: 9200

--- a/classes/system/galera/server/database/aodh.yml
+++ b/classes/system/galera/server/database/aodh.yml
@@ -11,5 +11,5 @@ parameters:
             rights: all
           - name: aodh
             password: ${_param:mysql_aodh_password}
-            host: ${_param:cluster_local_address}
+            host: ${_param:cluster_vip_address}
             rights: all

--- a/classes/system/heka/ceilometer_collector/single.yml
+++ b/classes/system/heka/ceilometer_collector/single.yml
@@ -5,8 +5,8 @@ parameters:
     ceilometer_collector:
       enabled: true
       influxdb_database: ceilometer
-      influxdb_host: ${_param:monitoring_service_address}
-      influxdb_password: ${_param:stacklight_influxdb_password}
+      influxdb_host: ${_param:stacklight_monitor_node01_address}
+      influxdb_password: ${_param:_param:influxdb_password}
       influxdb_port: 8086
       influxdb_username: ceilometer
       resource_decoding: false


### PR DESCRIPTION
Ceilometer and Aodh classes use couple of non actual config names. This CR fix it.   