### PR TITLE
Add 9.0-latest repository for python-influxdb installation

### DIFF
--- a/classes/cluster/mk22_lab_basic/openstack/control.yml
+++ b/classes/cluster/mk22_lab_basic/openstack/control.yml
@@ -31,6 +31,18 @@ parameters:
       package:
         python-msgpack:
           version: latest
+      repo:
+      # This repository is needed because the python-influxdb package
+      # required for Mitaka Ceilometer is only present in
+      # mos9.0-proposed from the 9.0-latest repository
+        mirantis_latest_openstack_proposed:
+          source: "deb http://mirror.fuel-infra.org/mos-repos/ubuntu/snapshots/9.0-latest/ mos9.0-proposed main"
+          architectures: amd64
+          key_url: "http://mirror.fuel-infra.org/mos-repos/ubuntu/snapshots/9.0-latest/archive-mos9.0.key"
+          pin:
+            - pin: "release a=mos9.0-proposed"
+              priority: 400
+              package: "*"
     network:
       interface:
         eth1:

--- a/classes/system/linux/system/repo/mos9.yml
+++ b/classes/system/linux/system/repo/mos9.yml
@@ -10,10 +10,6 @@ parameters:
           source: "deb http://mirror.fuel-infra.org/mos-repos/ubuntu/9.0/ mos9.0-hotfix main restricted"
           architectures: amd64
           key_url: "http://mirror.fuel-infra.org/mos-repos/ubuntu/9.0/archive-mos9.0.key"
-        mirantis_openstack_proposed:
-          source: "deb http://mirror.fuel-infra.org/mos-repos/ubuntu/9.0/ mos9.0-proposed main restricted"
-          architectures: amd64
-          key_url: "http://mirror.fuel-infra.org/mos-repos/ubuntu/9.0/archive-mos9.0.key"
         mirantis_openstack_security:
           source: "deb http://mirror.fuel-infra.org/mos-repos/ubuntu/9.0/ mos9.0-security main restricted"
           architectures: amd64


### PR DESCRIPTION
Python-influxdb is needed for Ceilometer in Mitaka. Because
this package provided by nightly xenial repository we add
and pin this repository with lower priority.