### PR TITLE
Use policy status_of_members for node clusters

### DIFF
--- a/classes/system/heka/alarm/openstack_compute.yml
+++ b/classes/system/heka/alarm/openstack_compute.yml
@@ -73,7 +73,7 @@ parameters:
     aggregator:
       alarm_cluster:
         compute_nodes:
-          policy: majority_of_members
+          policy: status_of_members
           alerting: enabled_with_notification
           group_by: hostname
           match:

--- a/classes/system/heka/alarm/openstack_control.yml
+++ b/classes/system/heka/alarm/openstack_control.yml
@@ -85,7 +85,7 @@ parameters:
     aggregator:
       alarm_cluster:
         control_nodes:
-          policy: majority_of_members
+          policy: status_of_members
           alerting: enabled_with_notification
           group_by: hostname
           match:


### PR DESCRIPTION
We will remove the `majority_of_members` policy in the (near) future. This change suggests using `status_of_members` for the `control_nodes` and `compute_nodes` alarm clusters.