### PR TITLE
Fixed mk20_lab_advanced

### DIFF
--- a/classes/cluster/mk20_lab_advanced/fuel/config.yml
+++ b/classes/cluster/mk20_lab_advanced/fuel/config.yml
@@ -13,7 +13,7 @@ classes:
 - system.keystone.client.service.nova
 - system.mysql.client.single
 - system.reclass.storage.system.openstack_control_cluster
-- system.reclass.storage.system.openstack_compute_single
+- system.reclass.storage.system.openstack_compute_multi
 - system.reclass.storage.system.openstack_dashboard_single
 - system.reclass.storage.system.monitoring_service_single
 - cluster.mk20_lab_advanced

--- a/classes/cluster/mk20_lab_advanced/openstack/compute.yml
+++ b/classes/cluster/mk20_lab_advanced/openstack/compute.yml
@@ -3,7 +3,6 @@ classes:
 - system.linux.system.repo.mos8
 - system.nova.compute.cluster
 - system.opencontrail.compute.cluster
-- system.ceilometer.compute.cluster
 - cluster.mk20_lab_advanced
 parameters:
   linux:


### PR DESCRIPTION
Ceilometer out from compute node(s).
Changed to two computes.