### PR TITLE
Add Ceilometer and Aodh haproxy importing to sysclasses

### DIFF
--- a/classes/system/aodh/server/cluster.yml
+++ b/classes/system/aodh/server/cluster.yml
@@ -1,4 +1,4 @@
 classes:
 - service.aodh.server.cluster
-- service.haproxy.proxy.single
+- system.haproxy.proxy.listen.openstack.aodh
 - service.keepalived.cluster.single

--- a/classes/system/ceilometer/server/cluster.yml
+++ b/classes/system/ceilometer/server/cluster.yml
@@ -1,6 +1,6 @@
 classes:
 - service.ceilometer.server.cluster
-- service.haproxy.proxy.single
+- system.haproxy.proxy.listen.openstack.ceilometer
 - service.keepalived.cluster.single
 parameters:
   ceilometer:


### PR DESCRIPTION
Currently classes for Aodh and Ceilometer haproxies are referenced
from model. In this commit referencing is moved to sysclasses
for cluster deployment