### PR TITLE
Add Openstack Telemetry to mk22_lab_basic and mk22_lab_advanced

### DIFF
--- a/classes/cluster/mk22_lab_advanced/fuel/config.yml
+++ b/classes/cluster/mk22_lab_advanced/fuel/config.yml
@@ -9,6 +9,8 @@ classes:
 - system.salt.minion.pki.certificate
 - system.sphinx.server.doc.reclass
 - system.keystone.client.single
+- system.keystone.client.service.aodh
+- system.keystone.client.service.ceilometer
 - system.keystone.client.service.nova21
 - system.mysql.client.single
 - system.reclass.storage.system.openstack_control_cluster

--- a/classes/cluster/mk22_lab_advanced/openstack/compute.yml
+++ b/classes/cluster/mk22_lab_advanced/openstack/compute.yml
@@ -41,3 +41,10 @@ parameters:
         topics: notifications
         notify_on:
           state_change: vm_and_task_state
+  ceilometer:
+    agent:
+      message_queue:
+        members:
+          - host: ${_param:openstack_control_node01_address}
+          - host: ${_param:openstack_control_node02_address}
+          - host: ${_param:openstack_control_node03_address}

--- a/classes/cluster/mk22_lab_advanced/openstack/control.yml
+++ b/classes/cluster/mk22_lab_advanced/openstack/control.yml
@@ -2,6 +2,7 @@ classes:
 - system.linux.system.lowmem
 - system.linux.system.repo.contrail
 - system.linux.system.repo.mos9
+- system.linux.system.repo.mos9_latest
 - system.linux.system.repo.tcp_extra
 - system.memcached.server.single
 - system.rabbitmq.server.cluster
@@ -12,8 +13,12 @@ classes:
 - system.neutron.control.cluster
 - system.cinder.control.cluster
 - system.heat.server.cluster
+- system.ceilometer.server.cluster
+- system.aodh.server.cluster
 - system.opencontrail.control.cluster
+- system.heka.ceilometer_collector.single
 - system.galera.server.cluster
+- system.galera.server.database.aodh
 - system.galera.server.database.ceilometer
 - system.galera.server.database.cinder
 - system.galera.server.database.glance

--- a/classes/cluster/mk22_lab_advanced/openstack/init.yml
+++ b/classes/cluster/mk22_lab_advanced/openstack/init.yml
@@ -30,7 +30,9 @@ parameters:
     heat_service_host: ${_param:cluster_vip_address}
     heat_domain_admin_password: workshop
     ceilometer_version: ${_param:openstack_version}
-    ceilometer_service_host: 172.16.10.108
+    ceilometer_service_host: ${_param:cluster_vip_address}
+    aodh_version: ${_param:openstack_version}
+    aodh_service_host: ${_param:cluster_vip_address}
     cinder_version: ${_param:openstack_version}
     cinder_service_host: ${_param:cluster_vip_address}
     ceilometer_graphite_publisher_host: 172.16.10.107
@@ -43,6 +45,7 @@ parameters:
     glusterfs_service_host: ${_param:cluster_vip_address}
     mysql_admin_user: root
     mysql_admin_password: workshop
+    mysql_aodh_password: workshop
     mysql_cinder_password: workshop
     mysql_ceilometer_password: workshop
     mysql_glance_password: workshop
@@ -53,6 +56,7 @@ parameters:
     mysql_nova_password: workshop
     keystone_service_token: workshop
     keystone_admin_password: workshop
+    keystone_aodh_password: workshop
     keystone_ceilometer_password: workshop
     keystone_cinder_password: workshop
     keystone_glance_password: workshop

--- a/classes/cluster/mk22_lab_advanced/openstack/init.yml
+++ b/classes/cluster/mk22_lab_advanced/openstack/init.yml
@@ -74,6 +74,7 @@ parameters:
     mongodb_ceilometer_password: cloudlab
     mongodb_admin_password: cloudlab
     mongodb_shared_key: eoTh1AwahlahqueingeejooLughah4tei9feing0eeVaephooDi2li1TaeV1ooth
+    ceilometer_influxdb_password: lmapass
   linux:
     network:
       host:

--- a/classes/cluster/mk22_lab_advanced/stacklight/server.yml
+++ b/classes/cluster/mk22_lab_advanced/stacklight/server.yml
@@ -7,6 +7,7 @@ classes:
 - system.kibana.server.single
 - system.grafana.server.single
 - system.nagios.server.cluster
+- system.influxdb.database.ceilometer
 - cluster.mk22_lab_advanced
 - system.haproxy.proxy.listen.stacklight.elasticsearch
 - system.haproxy.proxy.listen.stacklight.kibana

--- a/classes/cluster/mk22_lab_basic/fuel/config.yml
+++ b/classes/cluster/mk22_lab_basic/fuel/config.yml
@@ -9,6 +9,8 @@ classes:
 - system.salt.minion.pki.certificate
 - system.sphinx.server.doc.reclass
 - system.keystone.client.single
+- system.keystone.client.service.aodh
+- system.keystone.client.service.ceilometer
 - system.keystone.client.service.nova21
 - system.mysql.client.single
 - system.reclass.storage.system.openstack_control_cluster

--- a/classes/cluster/mk22_lab_basic/openstack/compute.yml
+++ b/classes/cluster/mk22_lab_basic/openstack/compute.yml
@@ -2,6 +2,7 @@ classes:
 - system.linux.system.repo.contrail
 - system.linux.system.repo.mos9
 - system.nova.compute.cluster
+- system.ceilometer.agent.cluster
 - system.opencontrail.compute.cluster
 - system.heka.alarm.openstack_compute
 - service.opencontrail.compute.cluster
@@ -36,6 +37,13 @@ parameters:
         topics: notifications
         notify_on:
           state_change: vm_and_task_state
+      message_queue:
+        members:
+          - host: ${_param:openstack_control_node01_address}
+          - host: ${_param:openstack_control_node02_address}
+          - host: ${_param:openstack_control_node03_address}
+  ceilometer:
+    agent:
       message_queue:
         members:
           - host: ${_param:openstack_control_node01_address}

--- a/classes/cluster/mk22_lab_basic/openstack/control.yml
+++ b/classes/cluster/mk22_lab_basic/openstack/control.yml
@@ -2,6 +2,7 @@ classes:
 - system.linux.system.lowmem
 - system.linux.system.repo.contrail
 - system.linux.system.repo.mos9
+- system.linux.system.repo.mos9_latest
 - system.linux.system.repo.tcp_extra
 - system.memcached.server.single
 - system.rabbitmq.server.cluster
@@ -12,8 +13,12 @@ classes:
 - system.neutron.control.cluster
 - system.cinder.control.cluster
 - system.heat.server.cluster
+- system.ceilometer.server.cluster
+- system.aodh.server.cluster
 - system.opencontrail.control.cluster
+- system.heka.ceilometer_collector.single
 - system.galera.server.cluster
+- system.galera.server.database.aodh
 - system.galera.server.database.ceilometer
 - system.galera.server.database.cinder
 - system.galera.server.database.glance
@@ -31,18 +36,6 @@ parameters:
       package:
         python-msgpack:
           version: latest
-      repo:
-      # This repository is needed because the python-influxdb package
-      # required for Mitaka Ceilometer is only present in
-      # mos9.0-proposed from the 9.0-latest repository
-        mirantis_latest_openstack_proposed:
-          source: "deb http://mirror.fuel-infra.org/mos-repos/ubuntu/snapshots/9.0-latest/ mos9.0-proposed main"
-          architectures: amd64
-          key_url: "http://mirror.fuel-infra.org/mos-repos/ubuntu/snapshots/9.0-latest/archive-mos9.0.key"
-          pin:
-            - pin: "release a=mos9.0-proposed"
-              priority: 400
-              package: "*"
     network:
       interface:
         eth1:

--- a/classes/cluster/mk22_lab_basic/openstack/init.yml
+++ b/classes/cluster/mk22_lab_basic/openstack/init.yml
@@ -73,6 +73,8 @@ parameters:
     mongodb_ceilometer_password: cloudlab
     mongodb_admin_password: cloudlab
     mongodb_shared_key: eoTh1AwahlahqueingeejooLughah4tei9feing0eeVaephooDi2li1TaeV1ooth
+    ceilometer_influxdb_password: lmapass
+
   linux:
     network:
       host:

--- a/classes/cluster/mk22_lab_basic/openstack/init.yml
+++ b/classes/cluster/mk22_lab_basic/openstack/init.yml
@@ -29,7 +29,9 @@ parameters:
     heat_service_host: ${_param:cluster_vip_address}
     heat_domain_admin_password: workshop
     ceilometer_version: ${_param:openstack_version}
-    ceilometer_service_host: 172.16.10.108
+    ceilometer_service_host: ${_param:cluster_vip_address}
+    aodh_version: ${_param:openstack_version}
+    aodh_service_host: ${_param:cluster_vip_address}
     cinder_version: ${_param:openstack_version}
     cinder_service_host: ${_param:cluster_vip_address}
     ceilometer_graphite_publisher_host: 172.16.10.107
@@ -42,6 +44,7 @@ parameters:
     glusterfs_service_host: ${_param:cluster_vip_address}
     mysql_admin_user: root
     mysql_admin_password: workshop
+    mysql_aodh_password: workshop
     mysql_cinder_password: workshop
     mysql_ceilometer_password: workshop
     mysql_glance_password: workshop
@@ -52,6 +55,7 @@ parameters:
     mysql_nova_password: workshop
     keystone_service_token: workshop
     keystone_admin_password: workshop
+    keystone_aodh_password: workshop
     keystone_ceilometer_password: workshop
     keystone_cinder_password: workshop
     keystone_glance_password: workshop

--- a/classes/cluster/mk22_lab_basic/stacklight/server.yml
+++ b/classes/cluster/mk22_lab_basic/stacklight/server.yml
@@ -5,6 +5,7 @@ classes:
 - system.elasticsearch.server.single
 - system.elasticsearch.server.curator
 - system.influxdb.server.single
+- system.influxdb.database.ceilometer
 - system.kibana.server.single
 - system.grafana.server.single
 - system.nagios.server.single

--- a/classes/system/ceilometer/server/cluster.yml
+++ b/classes/system/ceilometer/server/cluster.yml
@@ -10,7 +10,7 @@ parameters:
           host: ${_param:stacklight_monitor_node01_address}
           port: 8086
           user: ceilometer
-          password: ${_param:stacklight_influxdb_password}
+          password: ${_param:ceilometer_influxdb_password}
           database: ceilometer
         elasticsearch:
           enabled: true

--- a/classes/system/ceilometer/server/single.yml
+++ b/classes/system/ceilometer/server/single.yml
@@ -8,7 +8,7 @@ parameters:
           host: ${_param:stacklight_monitor_node01_address}
           port: 8086
           user: ceilometer
-          password: ${_param:stacklight_influxdb_password}
+          password: ${_param:ceilometer_influxdb_password}
           database: ceilometer
         elasticsearch:
           enabled: true

--- a/classes/system/heka/ceilometer_collector/single.yml
+++ b/classes/system/heka/ceilometer_collector/single.yml
@@ -7,7 +7,7 @@ parameters:
       enabled: true
       influxdb_database: ceilometer
       influxdb_host: ${_param:stacklight_monitor_node01_address}
-      influxdb_password: ${_param:_param:influxdb_password}
+      influxdb_password: ${_param:ceilometer_influxdb_password}
       influxdb_port: 8086
       influxdb_username: ceilometer
       resource_decoding: false

--- a/classes/system/influxdb/database/ceilometer.yml
+++ b/classes/system/influxdb/database/ceilometer.yml
@@ -14,7 +14,7 @@ parameters:
         ceilometer:
           enabled: true
           name: ceilometer
-          password: ${_param:influxdb_stacklight_password}
+          password: ${_param:ceilometer_influxdb_password}
       grant:
         grant_ceilometer_all:
           enabled: true

--- a/classes/system/influxdb/database/ceilometer.yml
+++ b/classes/system/influxdb/database/ceilometer.yml
@@ -1,0 +1,23 @@
+parameters:
+  influxdb:
+    server:
+      database:
+        ceilometer:
+          enabled: true
+          name: ceilometer
+          retention_policy:
+            - name: ceilometer
+              is_default: true
+              duration: 30d
+              replication: 1
+      user:
+        ceilometer:
+          enabled: true
+          name: ceilometer
+          password: ${_param:influxdb_stacklight_password}
+      grant:
+        grant_ceilometer_all:
+          enabled: true
+          user: ceilometer
+          database: ceilometer
+          privilege: all

--- a/classes/system/linux/system/repo/mos9_latest.yml
+++ b/classes/system/linux/system/repo/mos9_latest.yml
@@ -1,0 +1,18 @@
+parameters:
+  linux:
+    system:
+      package:
+        python-msgpack:
+          version: latest
+      repo:
+      # This repository is needed because the python-influxdb package
+      # required for Mitaka Ceilometer is only present in
+      # mos9.0-proposed from the 9.0-latest repository
+        mirantis_latest_openstack_proposed:
+          source: "deb http://mirror.fuel-infra.org/mos-repos/ubuntu/snapshots/9.0-latest/ mos9.0-proposed main"
+          architectures: amd64
+          key_url: "http://mirror.fuel-infra.org/mos-repos/ubuntu/snapshots/9.0-latest/archive-mos9.0.key"
+          pin:
+            - pin: "release a=mos9.0-proposed"
+              priority: 400
+              package: "*"

--- a/scripts/openstack_control_install.sh
+++ b/scripts/openstack_control_install.sh
@@ -35,3 +35,10 @@ salt -C 'I@keystone:server' cmd.run ". /root/keystonerc; heat resource-type-list
 # Install horizon dashboard
 salt -C 'I@horizon:server' state.sls horizon
 salt -C 'I@nginx:server' state.sls nginx
+
+# Install ceilometer services
+salt -C 'I@ceilometer:server' state.sls ceilometer -b 1
+salt -C 'I@heka:ceilometer_collector:enabled:True' state.sls heka.ceilometer_collector
+
+# Install aodh services
+salt -C 'I@aodh:server' state.sls aodh -b 1


### PR DESCRIPTION
This PR contains a changes which add right configs and classes for allowing Ceilometer, Aodh and ceilometer-collector into mk22_lab_basic and mk22_lab_advanced models.

Also, it contains one configs fix for Ceilometer and adding deployment mentioned applications to scripts