### PR TITLE
Split GlusterFS install from the Elastic class

### DIFF
--- a/classes/cluster/mk22_full_scale/stacklight/log.yml
+++ b/classes/cluster/mk22_full_scale/stacklight/log.yml
@@ -1,5 +1,6 @@
 classes:
 - system.elasticsearch.server.cluster
+- system.elasticsearch.server.storage.glusterfs
 - system.elasticsearch.server.curator
 - system.linux.system.repo.saltstack_2016_3
 - system.haproxy.proxy.listen.elasticsearch

--- a/classes/cluster/mk22_scale_mirantis/stacklight/log.yml
+++ b/classes/cluster/mk22_scale_mirantis/stacklight/log.yml
@@ -1,5 +1,6 @@
 classes:
 - system.elasticsearch.server.cluster
+- system.elasticsearch.server.storage.glusterfs
 - system.linux.system.repo.saltstack_2016_3
 - system.haproxy.proxy.listen.elasticsearch
 - cluster.mk22_scale_mirantis

--- a/classes/system/elasticsearch/server/cluster.yml
+++ b/classes/system/elasticsearch/server/cluster.yml
@@ -1,8 +1,6 @@
 classes:
 - service.elasticsearch.server.cluster
 - service.java.environment
-- service.glusterfs.server
-- service.glusterfs.client
 parameters:
   _param:
     java_environment_version: "8"
@@ -45,34 +43,3 @@ parameters:
         - host: ${_param:cluster_node01_address}
         - host: ${_param:cluster_node02_address}
         - host: ${_param:cluster_node03_address}
-      snapshot:
-        repo:
-          path: /var/lib/elasticsearch/repo
-  glusterfs:
-    server:
-      peers:
-        - ${_param:cluster_node01_address}
-        - ${_param:cluster_node02_address}
-        - ${_param:cluster_node03_address}
-      volumes:
-        elasticrepo:
-          storage: /srv/glusterfs/elasticrepo
-          replica: 3
-          bricks:
-            - ${_param:cluster_node01_address}:/srv/glusterfs/elasticrepo
-            - ${_param:cluster_node02_address}:/srv/glusterfs/elasticrepo
-            - ${_param:cluster_node03_address}:/srv/glusterfs/elasticrepo
-          options:
-            cluster.readdir-optimize: On
-            cluster.lookup-optimize: On
-            nfs.disable: On
-            network.remote-dio: On
-            diagnostics.client-log-level: WARNING
-            diagnostics.brick-log-level: WARNING
-    client:
-      volumes:
-        elasticrepo:
-          path: /var/lib/elasticsearch/repo
-          server: ${_param:cluster_node01_address}
-          user: elasticsearch
-          group: elasticsearch

--- a/classes/system/elasticsearch/server/storage/glusterfs.yml
+++ b/classes/system/elasticsearch/server/storage/glusterfs.yml
@@ -1,0 +1,37 @@
+classes:
+- service.glusterfs.server
+- service.glusterfs.client
+parameters:
+  elasticsearch:
+    server:
+      snapshot:
+        repo:
+          path: /var/lib/elasticsearch/repo
+  glusterfs:
+    server:
+      peers:
+        - ${_param:cluster_node01_address}
+        - ${_param:cluster_node02_address}
+        - ${_param:cluster_node03_address}
+      volumes:
+        elasticrepo:
+          storage: /srv/glusterfs/elasticrepo
+          replica: 3
+          bricks:
+            - ${_param:cluster_node01_address}:/srv/glusterfs/elasticrepo
+            - ${_param:cluster_node02_address}:/srv/glusterfs/elasticrepo
+            - ${_param:cluster_node03_address}:/srv/glusterfs/elasticrepo
+          options:
+            cluster.readdir-optimize: On
+            cluster.lookup-optimize: On
+            nfs.disable: On
+            network.remote-dio: On
+            diagnostics.client-log-level: WARNING
+            diagnostics.brick-log-level: WARNING
+    client:
+      volumes:
+        elasticrepo:
+          path: /var/lib/elasticsearch/repo
+          server: ${_param:cluster_node01_address}
+          user: elasticsearch
+          group: elasticsearch


### PR DESCRIPTION
This change separates the installation of GlusterFS for Elasticsearch
snapshots from the Elasticsearch system class for better flexibility.
It also removes the use of GlusterFS for the mk20 and mk22 StackLight
labs because it generates random errors during the deployment.