### PR TITLE
Add safety loop

### DIFF
--- a/scripts/common_functions.sh
+++ b/scripts/common_functions.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+# Function used to return list of node names according
+# to given string parameter match criteria
+function get_nodes_names {
+	# Enforce 1st parameter availability
+	if [ -z "$1" ]; then
+		match="[0-9]"
+	else
+		match="$1"
+	fi
+	salt-call pillar.get linux:network:host --out key | sed 's/:.*//' | grep "$match"
+}
+
 # Function used to wait for node availability
 # (aka answering to salt pings)
 # 1st parameter (mandatory) is number of nodes to wait for

--- a/scripts/common_functions.sh
+++ b/scripts/common_functions.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Function used to wait for node availability
+# (aka answering to salt pings)
+# 1st parameter (mandatory) is number of nodes to wait for
+# 2nd parameter (optional) is nodes names to wait for
+#    (* = all nodes is default)
+function wait_for {
+	# Enforce 1st parameter availability
+	if [ -z "$1" ]; then
+		echo "wait_for function requires at least 1 parameter"
+		return 1
+	fi
+	if [ -n "$(echo $1 | sed -e 's/[1-9][0-9]*//')" ]; then
+		echo "wait_for function requires 1st parameter to be number greater than 0 ($1 invalid)"
+		return 1
+	fi
+	wanted=$1
+	nodes=${2:-"*"}
+	# Default max waiting time is 5mn
+	MAX_WAIT=${MAX_WAIT:-300}
+	while [ true ]; do
+		nb_nodes=$(salt "$nodes" test.ping --out txt | grep True | wc -l)
+		if [ -n "$nb_nodes" ] && [ $nb_nodes -eq $wanted ]; then
+			echo "All nodes are now answering to salt pings"
+			break
+		fi
+		MAX_WAIT=$(( $MAX_WAIT - 15 ))
+		if [ $MAX_WAIT -le 0 ]; then
+			echo "Only $nb_nodes answering to salt pings out of $wanted after maximum timeout"
+			return 2
+		fi
+		echo -n "Only $nb_nodes answering to salt pings out of $wanted. Waiting a bit longer ..."
+		sleep 15
+		echo
+	done
+	return 0
+}

--- a/scripts/fuel_config_verify.sh
+++ b/scripts/fuel_config_verify.sh
@@ -1,6 +1,14 @@
 #!/bin/bash -x
 exec > >(tee -i /tmp/$(basename $0 .sh)_$(date '+%Y-%m-%d_%H-%M-%S').log) 2>&1
 
+# Import common functions
+COMMONS=./common_functions.sh
+if [ ! -f $COMMONS ]; then
+	echo "File $COMMONS does not exist"
+	exit 1
+fi
+. $COMMONS
+
 # Verify that Salt master is correctly bootstrapped
 salt-key
 reclass-salt --top
@@ -9,23 +17,5 @@ reclass-salt --top
 salt-call --version
 salt '*' test.version
 
-# Get number of hostnames in current deployment
-wanted=$(salt-call pillar.get linux:network:host --out key | sed 's/:.*//' | grep '[0-9]' | wc -l)
-
-# Default max waiting time is 5mn
-MAX_WAIT=${MAX_WAIT:-300}
-while [ true ]; do
-	nb_nodes=$(salt '*' test.ping --out txt | grep True | wc -l)
-	if [ -n "$nb_nodes" ] && [ $nb_nodes -eq $wanted ]; then
-		echo "All nodes are now answering to salt pings"
-		break
-	fi
-	MAX_WAIT=$(( $MAX_WAIT - 15 ))
-	if [ $MAX_WAIT -le 0 ]; then
-		echo "Only $nb_nodes answering to salt pings out of $wanted after maximum timeout"
-		exit 1
-	fi
-	echo -n "Only $nb_nodes answering to salt pings out of $wanted. Waiting a bit longer ..."
-	sleep 15
-	echo
-done
+# Wait for all nodes in current deployment to be available
+wait_for $(salt-call pillar.get linux:network:host --out key | sed 's/:.*//' | grep '[0-9]' | wc -l)

--- a/scripts/fuel_config_verify.sh
+++ b/scripts/fuel_config_verify.sh
@@ -18,4 +18,4 @@ salt-call --version
 salt '*' test.version
 
 # Wait for all nodes in current deployment to be available
-wait_for $(salt-call pillar.get linux:network:host --out key | sed 's/:.*//' | grep '[0-9]' | wc -l)
+wait_for $(get_nodes_names | wc -l)

--- a/scripts/fuel_config_verify.sh
+++ b/scripts/fuel_config_verify.sh
@@ -8,3 +8,25 @@ reclass-salt --top
 # Verify that Salt minions are responding and the same version as master
 salt-call --version
 salt '*' test.version
+
+# Get list of hostnames in current deployment
+hosts=(`salt-call pillar.get linux:network:host | egrep '0.*:' | sed -e 's/  *//' -e 's/://'`)
+wanted=${#hosts[@]}
+
+# Default max waiting time is 5mn
+MAX_WAIT=${MAX_WAIT:-300}
+while [ true ]; do
+	nb_nodes=`salt '*' test.ping | egrep ':$' | wc -l`
+	if [ -n "$nb_nodes" ] && [ $nb_nodes -eq $wanted ]; then
+		echo "All nodes are now answering to salt pings"
+		break
+	fi
+	MAX_WAIT=`expr $MAX_WAIT - 15`
+	if [ $MAX_WAIT -le 0 ]; then
+		echo "Only $nb_nodes answering to salt pings out of $wanted after maximum timeout"
+		exit 1
+	fi
+	echo -n "Only $nb_nodes answering to salt pings out of $wanted. Waiting a bit longer ..."
+	sleep 15
+	echo
+done


### PR DESCRIPTION
This prevents errors when lauching deployment scritps
too early (aka when all nodes are not yet bootstrapped
and answering to salt pings)