### PR TITLE
Add two topics for openstack notifications

### DIFF
--- a/classes/cluster/mk22_lab_basic/openstack/compute.yml
+++ b/classes/cluster/mk22_lab_basic/openstack/compute.yml
@@ -33,7 +33,9 @@ parameters:
       vncproxy_url: http://${_param:cluster_vip_address}:6080
       notification:
         driver: messagingv2
-        topics: notifications
+        topics:
+          - notifications
+          - ceilometer_notifications
         notify_on:
           state_change: vm_and_task_state
       message_queue:
@@ -41,3 +43,8 @@ parameters:
           - host: ${_param:openstack_control_node01_address}
           - host: ${_param:openstack_control_node02_address}
           - host: ${_param:openstack_control_node03_address}
+  ceilometer:
+    agent:
+      notification:
+        topics:
+          - ceilometer_notifications

--- a/classes/cluster/mk22_lab_basic/openstack/control.yml
+++ b/classes/cluster/mk22_lab_basic/openstack/control.yml
@@ -57,17 +57,26 @@ parameters:
   keystone:
     server:
       admin_email: ${_param:admin_email}
-      notification: true
+      notification:
+        topics:
+          - notifications
+          - ceilometer_notifications
   glance:
     server:
       storage:
         engine: file
       images: []
       workers: 1
-      notification: true
+      notification:
+        topics:
+          - notifications
+          - ceilometer_notifications
   heat:
     server:
-      notification: true
+      notification:
+        topics:
+          - notifications
+          - ceilometer_notifications
   nova:
     controller:
       networking: contrail
@@ -84,7 +93,10 @@ parameters:
         - host: 127.0.0.1
           port: 11211
       workers: 1
-      notification: true
+      notification:
+        topics:
+          - notifications
+          - ceilometer_notifications
   neutron:
     server:
       plugin: contrail
@@ -95,6 +107,17 @@ parameters:
       notification: true
   cinder:
     volume:
-      notification: true
+      notification:
+        topics:
+          - notifications
+          - ceilometer_notifications
     controller:
-      notification: true
+      notification:
+        topics:
+          - notifications
+          - ceilometer_notifications
+  ceilometer:
+    server:
+      notification:
+        topics:
+          - ceilometer_notifications


### PR DESCRIPTION
This change need, because we have two receivers for openstack
notifications:

- remote_collector (it should listen 'notifications' topic)
- ceilometer-agent-notification (it should listen 'ceilometer_notification' topic)
    
Otherwise there is concurent receiving of messages