### PR TITLE
Use the rsyslog formula and state

### DIFF
--- a/classes/cluster/mk20_stacklight_advanced/init.yml
+++ b/classes/cluster/mk20_stacklight_advanced/init.yml
@@ -1,5 +1,6 @@
 classes:
 - system.linux.system.single
+- system.rsyslog.client.single
 - cluster.mk20_stacklight_advanced.fuel
 - cluster.mk20_stacklight_advanced.openstack
 - cluster.mk20_stacklight_advanced.stacklight

--- a/classes/cluster/mk20_stacklight_basic/init.yml
+++ b/classes/cluster/mk20_stacklight_basic/init.yml
@@ -1,5 +1,6 @@
 classes:
 - system.linux.system.single
+- system.rsyslog.client.single
 - cluster.mk20_stacklight_basic.fuel
 - cluster.mk20_stacklight_basic.openstack
 - cluster.mk20_stacklight_basic.stacklight

--- a/classes/cluster/mk22_full_scale/init.yml
+++ b/classes/cluster/mk22_full_scale/init.yml
@@ -2,6 +2,7 @@ classes:
 - system.linux.system.single
 - system.linux.system.repo.saltstack_2016_3
 - system.openssh.server.team.tcpcloud
+- system.rsyslog.client.single
 - cluster.mk22_full_scale.fuel
 - cluster.mk22_full_scale.openstack
 - cluster.mk22_full_scale.opencontrail

--- a/classes/cluster/mk22_lab_advanced/init.yml
+++ b/classes/cluster/mk22_lab_advanced/init.yml
@@ -1,5 +1,6 @@
 classes:
 - system.linux.system.single
+- system.rsyslog.client.single
 - cluster.mk22_lab_advanced.fuel
 - cluster.mk22_lab_advanced.openstack
 - cluster.mk22_lab_advanced.stacklight

--- a/classes/cluster/mk22_lab_basic/init.yml
+++ b/classes/cluster/mk22_lab_basic/init.yml
@@ -1,5 +1,6 @@
 classes:
 - system.linux.system.single
+- system.rsyslog.client.single
 - cluster.mk22_lab_basic.fuel
 - cluster.mk22_lab_basic.openstack
 - cluster.mk22_lab_basic.stacklight

--- a/classes/system/rsyslog/client/single.yml
+++ b/classes/system/rsyslog/client/single.yml
@@ -1,0 +1,2 @@
+classes:
+- service.rsyslog.client.single

--- a/classes/system/salt/master/formula/git/stacklight.yml
+++ b/classes/system/salt/master/formula/git/stacklight.yml
@@ -71,6 +71,9 @@ parameters:
               address: '${_param:salt_master_environment_repository}/salt-formula-redis.git'
               revision: ${_param:salt_master_environment_revision}
             rsyslog:
+              module:
+                rsyslog_util.py:
+                  enabled: true
               source: git
               address: '${_param:salt_master_environment_repository}/salt-formula-rsyslog.git'
               revision: ${_param:salt_master_environment_revision}

--- a/scripts/fuel_infra_install.sh
+++ b/scripts/fuel_infra_install.sh
@@ -13,4 +13,4 @@ salt '*' saltutil.sync_all
 sleep 5
 
 # Bootstrap all nodes
-salt "*" state.sls linux,openssh,salt.minion,ntp
+salt "*" state.sls linux,openssh,salt.minion,ntp,rsyslog


### PR DESCRIPTION
With this change the `rsyslog` state is applied on all the nodes of the cluster. This change requires https://github.com/tcpcloud/salt-formula-rsyslog/pull/1.