### PR TITLE
Fix inconsistent Stacklight environment label

### DIFF
--- a/classes/cluster/mk20_stacklight_advanced/stacklight/init.yml
+++ b/classes/cluster/mk20_stacklight_advanced/stacklight/init.yml
@@ -22,6 +22,7 @@ parameters:
     nagios_notification_smtp_server: 127.0.0.1
     nagios_notification_from: 'nagios@localhost'
     nagios_notification_email: 'root@localhost'
+    stacklight_environment: ${_param:cluster_domain}
   linux:
     network:
       host:

--- a/classes/cluster/mk20_stacklight_basic/stacklight/init.yml
+++ b/classes/cluster/mk20_stacklight_basic/stacklight/init.yml
@@ -22,6 +22,7 @@ parameters:
     nagios_notification_smtp_server: 127.0.0.1
     nagios_notification_from: 'nagios@localhost'
     nagios_notification_email: 'root@localhost'
+    stacklight_environment: ${_param:cluster_domain}
   linux:
     network:
       host:

--- a/classes/cluster/mk22_full_scale/stacklight/init.yml
+++ b/classes/cluster/mk22_full_scale/stacklight/init.yml
@@ -22,6 +22,7 @@ parameters:
     nagios_notification_smtp_server: 127.0.0.1
     nagios_notification_from: 'nagios@localhost'
     nagios_notification_email: 'root@localhost'
+    stacklight_environment: ${_param:cluster_domain}
   linux:
     network:
       host:

--- a/classes/cluster/mk22_lab_basic/stacklight/init.yml
+++ b/classes/cluster/mk22_lab_basic/stacklight/init.yml
@@ -22,6 +22,7 @@ parameters:
     nagios_notification_smtp_server: 127.0.0.1
     nagios_notification_from: 'nagios@localhost'
     nagios_notification_email: 'root@localhost'
+    stacklight_environment: ${_param:cluster_domain}
   linux:
     network:
       host:

--- a/classes/cluster/mk22_scale_mirantis/stacklight/init.yml
+++ b/classes/cluster/mk22_scale_mirantis/stacklight/init.yml
@@ -22,6 +22,7 @@ parameters:
     nagios_notification_smtp_server: 127.0.0.1
     nagios_notification_from: 'nagios@localhost'
     nagios_notification_email: 'root@localhost'
+    stacklight_environment: ${_param:cluster_domain}
   linux:
     network:
       host:

--- a/classes/system/heka/server.yml
+++ b/classes/system/heka/server.yml
@@ -1,6 +1,4 @@
 parameters:
-  _param:
-    stacklight_environment: ${_param:cluster_domain}
   heka:
     server:
       extra_fields:

--- a/classes/system/nagios/server/init.yml
+++ b/classes/system/nagios/server/init.yml
@@ -3,7 +3,6 @@ parameters:
     nagios_notification_email: root@localhost
     nagios_host_dimension_key: nagios_host
     nagios_default_host_alarm_clusters: 00-clusters
-    stacklight_environment: ${_param:cluster_domain}
   nagios :
     server:
       enabled: true


### PR DESCRIPTION
The previous version generated inconsistent labels between the
monitoring nodes and the other nodes. This change makes
stacklight_environment a mandatory parameter to avoid this problem.