### PR TITLE
Revert "Wait for compute nodes to answer salt pings after reboot"

### DIFF
--- a/scripts/openstack_compute_install.sh
+++ b/scripts/openstack_compute_install.sh
@@ -1,14 +1,6 @@
 #!/bin/bash -x
 exec > >(tee -i /tmp/$(basename $0 .sh)_$(date '+%Y-%m-%d_%H-%M-%S').log) 2>&1
 
-# Import common functions
-COMMONS=./common_functions.sh
-if [ ! -f $COMMONS ]; then
-	echo "File $COMMONS does not exist"
-	exit 1
-fi
-. $COMMONS
-
 # Configure compute nodes
 salt "cmp*" state.apply
 salt "cmp*" state.apply
@@ -26,5 +18,4 @@ done
 # Reboot compute nodes
 salt "cmp*" system.reboot
 
-# Wait for all compute nodes in current deployment to be available
-wait_for $(get_nodes_names "cmp[0-9]" | wc -l) "cmp*"
+sleep 30


### PR DESCRIPTION
Reverts Mirantis/mk-lab-salt-model#201

I am suggesting to revert this because it does not work in all the cases. I have a case where the `wait_for` functions waits for 16 salt minions while I have only 10 in reality.

This is the output of `salt-call pillar.get linux:network:host --out key`:

```
Local Keys:
cfg:  {'names': ['cfg', 'cfg.mk22-lab-advanced.local'], 'address': '172.16.10.100'}
cfg01:  {'names': ['cfg01', 'cfg01.mk22-lab-advanced.local'], 'address': '172.16.10.100'}
cmp01:  {'names': ['cmp01', 'cmp01.mk22-lab-advanced.local'], 'address': '172.16.10.105'}
cmp02:  {'names': ['cmp02', 'cmp02.mk22-lab-advanced.local'], 'address': '172.16.10.106'}
ctl:  {'names': ['ctl', 'ctl.mk22-lab-advanced.local'], 'address': '172.16.10.254'}
ctl01:  {'names': ['ctl01', 'ctl01.mk22-lab-advanced.local'], 'address': '172.16.10.101'}
ctl02:  {'names': ['ctl02', 'ctl02.mk22-lab-advanced.local'], 'address': '172.16.10.102'}
ctl03:  {'names': ['ctl03', 'ctl03.mk22-lab-advanced.local'], 'address': '172.16.10.103'}
dbs:  {'names': ['dbs', 'dbs.mk22-lab-advanced.local'], 'address': '172.16.10.254'}
dbs01:  {'names': ['dbs01', 'dbs01.mk22-lab-advanced.local'], 'address': '172.16.10.101'}
dbs02:  {'names': ['dbs02', 'dbs02.mk22-lab-advanced.local'], 'address': '172.16.10.102'}
dbs03:  {'names': ['dbs03', 'dbs03.mk22-lab-advanced.local'], 'address': '172.16.10.102'}
mon:  {'names': ['mon', 'mon.mk22-lab-advanced.local'], 'address': '172.16.10.253'}
mon01:  {'names': ['mon01', 'mon01.mk22-lab-advanced.local'], 'address': '172.16.10.107'}
mon02:  {'names': ['mon02', 'mon02.mk22-lab-advanced.local'], 'address': '172.16.10.108'}
mon03:  {'names': ['mon03', 'mon03.mk22-lab-advanced.local'], 'address': '172.16.10.109'}
msg:  {'names': ['msg', 'msg.mk22-lab-advanced.local'], 'address': '172.16.10.254'}
msg01:  {'names': ['msg01', 'msg01.mk22-lab-advanced.local'], 'address': '172.16.10.101'}
msg02:  {'names': ['msg02', 'msg02.mk22-lab-advanced.local'], 'address': '172.16.10.102'}
msg03:  {'names': ['msg03', 'msg03.mk22-lab-advanced.local'], 'address': '172.16.10.103'}
prx:  {'names': ['prx', 'prx.mk22-lab-advanced.local'], 'address': '172.16.10.121'}
prx01:  {'names': ['prx01', 'prx01.mk22-lab-advanced.local'], 'address': '172.16.10.121'}
```

Note that there are multiple keys with the same address. So the number of keys is not the same as the number of minions.