### PR TITLE
Modify the test of the number of compute nodes

### DIFF
--- a/scripts/common_functions.sh
+++ b/scripts/common_functions.sh
@@ -23,7 +23,7 @@ function wait_for {
 		echo "wait_for function requires at least 1 parameter"
 		return 1
 	fi
-	if [ -n "${1/[1-9][0-9]*/}" ]; then
+	if [ "$1" -lt "1" ]; then
 		echo "wait_for function requires 1st parameter to be number greater than 0 ($1 invalid)"
 		return 1
 	fi


### PR DESCRIPTION
This patch modifies the way we check that the number of compute nodes is
greater than 0. It fixes an issue that occurs when extglob is disabled
and doesn't support the extending pattern matching.