### PR TITLE
Restart StackLight services associated to the VIP

### DIFF
--- a/scripts/stacklight_monitor_install.sh
+++ b/scripts/stacklight_monitor_install.sh
@@ -31,23 +31,21 @@ salt -C 'I@collectd:remote_client:enabled:True' state.sls collectd
 
 # Update Nagios
 salt -C 'I@nagios:server' state.sls nagios
+# Stop the Nagios service because the package starts it by default and it will
+# started later only on the node holding the VIP address
+salt -C 'I@nagios:server' service.stop nagios3
 
 # Finalize the configuration of Grafana (add the dashboards...)
 salt -C 'I@grafana:client' state.sls grafana.client.service
 salt -C 'I@grafana:client' --async service.restart salt-minion; sleep 10
 salt -C 'I@grafana:client' state.sls grafana.client
 
-# The following is only applied when StackLight is deployed in cluster
-# Get the StackLight VIP
+# Get the StackLight monitoring VIP addres
 vip=$(salt-call pillar.data _param:stacklight_monitor_address --out key|grep _param: |awk '{print $2}')
 vip=${vip:=172.16.10.253}
 
-# Start manually the services that are bound to the monitoring VIP
-salt -G "ipv4:$vip" service.start remote_collectd
-salt -G "ipv4:$vip" service.start remote_collector
-salt -G "ipv4:$vip" service.start aggregator
-
-# Stop Nagios on monitoring nodes (b/c the package starts it by default), then
-# start Nagios where the VIP is running.
-salt -C 'I@nagios:server:automatic_starting:False' service.stop nagios3
-salt -G "ipv4:$vip" service.start nagios3
+# (re)Start manually the services that are bound to the monitoring VIP
+salt -G "ipv4:$vip" service.restart remote_collectd
+salt -G "ipv4:$vip" service.restart remote_collector
+salt -G "ipv4:$vip" service.restart aggregator
+salt -G "ipv4:$vip" service.restart nagios3


### PR DESCRIPTION
This change makes sure that remote_collector, remote_collectd,
aggregator and nagios services are restarted when the corresponding
states are reapplied.