### PR TITLE
Replace ovs_lab_dvr by single_ovs_dvr

### DIFF
--- a/classes/cluster/mk22_lab_dvr/openstack/compute.yml
+++ b/classes/cluster/mk22_lab_dvr/openstack/compute.yml
@@ -3,7 +3,7 @@ classes:
 - system.linux.system.repo.mos9
 - system.nova.compute.cluster
 - system.neutron.compute.cluster
-- system.linux.network.interface.ovs_lab_dvr
+- system.linux.network.interface.single_ovs_dvr
 - cluster.mk22_lab_dvr
 - system.heka.alarm.openstack_compute
 parameters:

--- a/classes/cluster/mk22_lab_dvr/openstack/gateway.yml
+++ b/classes/cluster/mk22_lab_dvr/openstack/gateway.yml
@@ -2,7 +2,7 @@ classes:
 - system.linux.system.repo.contrail
 - system.linux.system.repo.mos9
 - system.linux.system.repo.tcp_extra
-- system.linux.network.interface.ovs_lab_dvr
+- system.linux.network.interface.single_ovs_dvr
 - system.neutron.gateway.cluster
 - cluster.mk22_lab_dvr
 parameters:

--- a/classes/cluster/mk22_lab_ovs/openstack/compute.yml
+++ b/classes/cluster/mk22_lab_ovs/openstack/compute.yml
@@ -3,7 +3,7 @@ classes:
 - system.linux.system.repo.mos9
 - system.nova.compute.cluster
 - system.neutron.compute.cluster
-- system.linux.network.interface.ovs_lab_dvr
+- system.linux.network.interface.single_ovs_dvr
 - cluster.mk22_lab_ovs
 parameters:
   _param:

--- a/classes/cluster/mk22_lab_ovs/openstack/gateway.yml
+++ b/classes/cluster/mk22_lab_ovs/openstack/gateway.yml
@@ -2,7 +2,7 @@ classes:
 - system.linux.system.repo.contrail
 - system.linux.system.repo.mos9
 - system.linux.system.repo.tcp_extra
-- system.linux.network.interface.ovs_lab_dvr
+- system.linux.network.interface.single_ovs_dvr
 - system.neutron.gateway.cluster
 - cluster.mk22_lab_ovs
 parameters:


### PR DESCRIPTION
This patch replaces the old declaration of the Linux network interface
since it has been renamed into single_ovs_dvr.