### PR TITLE
Add usage of InfluxDB backend for the Telemetry

### DIFF
--- a/classes/cluster/mk22_lab_advanced/init.yml
+++ b/classes/cluster/mk22_lab_advanced/init.yml
@@ -49,3 +49,5 @@ parameters:
     stacklight_monitor_node01_address: 172.16.10.107
     stacklight_monitor_node02_address: 172.16.10.108
     stacklight_monitor_node03_address: 172.16.10.109
+
+    stacklight_telemetry_node01_address: ${_param:stacklight_monitor_node01_address}

--- a/classes/cluster/mk22_lab_advanced/openstack/control.yml
+++ b/classes/cluster/mk22_lab_advanced/openstack/control.yml
@@ -16,6 +16,7 @@ classes:
 - system.cinder.control.cluster
 - system.heat.server.cluster
 - system.ceilometer.server.cluster
+- system.ceilometer.server.backend.influxdb
 - system.aodh.server.cluster
 - system.opencontrail.control.cluster
 - system.heka.ceilometer_collector.single

--- a/classes/cluster/mk22_lab_basic/init.yml
+++ b/classes/cluster/mk22_lab_basic/init.yml
@@ -47,3 +47,4 @@ parameters:
     # stacklight service addresses
     stacklight_monitor_address: 172.16.10.107
     stacklight_monitor_node01_address: 172.16.10.107
+    stacklight_telemetry_node01_address: ${_param:stacklight_monitor_node01_address}

--- a/classes/cluster/mk22_lab_basic/openstack/control.yml
+++ b/classes/cluster/mk22_lab_basic/openstack/control.yml
@@ -16,6 +16,7 @@ classes:
 - system.cinder.control.cluster
 - system.heat.server.cluster
 - system.ceilometer.server.cluster
+- system.ceilometer.server.backend.influxdb
 - system.aodh.server.cluster
 - system.opencontrail.control.cluster
 - system.heka.ceilometer_collector.single


### PR DESCRIPTION
Currently MongoDb class will be used by default during installation,
this code change it to InfluxDB and ElasticSearch