### PR TITLE
Move the Nginx proxy service to prx01 node

### DIFF
--- a/classes/cluster/mk22_lab_advanced/fuel/config.yml
+++ b/classes/cluster/mk22_lab_advanced/fuel/config.yml
@@ -17,6 +17,7 @@ classes:
 - system.reclass.storage.system.openstack_control_cluster
 - system.reclass.storage.system.openstack_compute_multi
 - system.reclass.storage.system.openstack_dashboard_single
+- system.reclass.storage.system.openstack_proxy_single
 - system.reclass.storage.system.stacklight_server_cluster
 - cluster.mk22_lab_advanced
 parameters:
@@ -54,3 +55,6 @@ parameters:
           - service.galera.slave.cluster
           params:
             mysql_cluster_role: slave
+        openstack_proxy_node01:
+          classes:
+          - cluster.mk22_lab_advanced.stacklight.proxy

--- a/classes/cluster/mk22_lab_advanced/fuel/config.yml
+++ b/classes/cluster/mk22_lab_advanced/fuel/config.yml
@@ -30,6 +30,7 @@ parameters:
     salt_master_base_environment: prd
     salt_minion_ca_host: ${linux:network:fqdn}
     salt_api_password_hash: "$6$sGnRlxGf$al5jMCetLP.vfI/fTl3Z0N7Za1aeiexL487jAtyRABVfT3NlwZxQGVhO7S1N8OwS/34VHYwZQA8lkXwKMN/GS1"
+    salt_master_api_port: 8088
   linux:
     network:
       interface:

--- a/classes/cluster/mk22_lab_advanced/openstack/proxy.yml
+++ b/classes/cluster/mk22_lab_advanced/openstack/proxy.yml
@@ -14,3 +14,4 @@ parameters:
       authority: mk_lab_ca
       engine: salt
       mode: secure
+    salt_minion_ca_host: cfg01.${_param:cluster_domain}

--- a/classes/cluster/mk22_lab_advanced/openstack/proxy.yml
+++ b/classes/cluster/mk22_lab_advanced/openstack/proxy.yml
@@ -11,7 +11,7 @@ parameters:
     cluster_vip_address: ${_param:openstack_proxy_address}
     nginx_proxy_ssl:
       enabled: true
-      authority: mk_lab_ca
+      authority: ${_param:salt_minion_ca_authority}
       engine: salt
       mode: secure
     salt_minion_ca_host: cfg01.${_param:cluster_domain}

--- a/classes/cluster/mk22_lab_advanced/stacklight/proxy.yml
+++ b/classes/cluster/mk22_lab_advanced/stacklight/proxy.yml
@@ -9,6 +9,6 @@ parameters:
   _param:
     nginx_proxy_ssl:
       enabled: true
-      authority: mk_lab_ca
+      authority: ${_param:salt_minion_ca_authority}
       engine: salt
       mode: secure

--- a/classes/cluster/mk22_lab_basic/fuel/config.yml
+++ b/classes/cluster/mk22_lab_basic/fuel/config.yml
@@ -16,6 +16,7 @@ classes:
 - system.reclass.storage.system.openstack_control_cluster
 - system.reclass.storage.system.openstack_compute_single
 - system.reclass.storage.system.openstack_dashboard_single
+- system.reclass.storage.system.openstack_proxy_single
 - system.reclass.storage.system.stacklight_server_single
 - cluster.mk22_lab_basic
 parameters:
@@ -52,3 +53,6 @@ parameters:
           - service.galera.slave.cluster
           params:
             mysql_cluster_role: slave
+        openstack_proxy_node01:
+          classes:
+          - cluster.mk22_lab_basic.stacklight.proxy

--- a/classes/cluster/mk22_lab_basic/fuel/config.yml
+++ b/classes/cluster/mk22_lab_basic/fuel/config.yml
@@ -28,6 +28,7 @@ parameters:
     salt_master_host: 127.0.0.1
     salt_master_base_environment: prd
     salt_minion_ca_host: ${linux:network:fqdn}
+    salt_master_api_port: 8088
   linux:
     network:
       interface:

--- a/classes/cluster/mk22_lab_basic/openstack/proxy.yml
+++ b/classes/cluster/mk22_lab_basic/openstack/proxy.yml
@@ -14,3 +14,4 @@ parameters:
       authority: mk_lab_ca
       engine: salt
       mode: secure
+    salt_minion_ca_host: cfg01.${_param:cluster_domain}

--- a/classes/cluster/mk22_lab_basic/openstack/proxy.yml
+++ b/classes/cluster/mk22_lab_basic/openstack/proxy.yml
@@ -11,7 +11,7 @@ parameters:
     cluster_vip_address: ${_param:openstack_proxy_address}
     nginx_proxy_ssl:
       enabled: true
-      authority: mk_lab_ca
+      authority: ${_param:salt_minion_ca_authority}
       engine: salt
       mode: secure
     salt_minion_ca_host: cfg01.${_param:cluster_domain}

--- a/classes/cluster/mk22_lab_basic/stacklight/proxy.yml
+++ b/classes/cluster/mk22_lab_basic/stacklight/proxy.yml
@@ -8,6 +8,6 @@ parameters:
   _param:
     nginx_proxy_ssl:
       enabled: true
-      authority: mk_lab_ca
+      authority: ${_param:salt_minion_ca_authority}
       engine: salt
       mode: secure

--- a/classes/cluster/mk22_lab_dvr/fuel/config.yml
+++ b/classes/cluster/mk22_lab_dvr/fuel/config.yml
@@ -18,6 +18,7 @@ classes:
 - system.reclass.storage.system.openstack_gateway_single
 - system.reclass.storage.system.openstack_dashboard_single
 - system.reclass.storage.system.stacklight_server_cluster
+- system.reclass.storage.system.openstack_proxy_single
 - cluster.mk22_lab_dvr
 parameters:
   _param:
@@ -70,3 +71,6 @@ parameters:
           params:
             tenant_address: 10.1.0.110
             external_address: 10.16.0.110
+        openstack_proxy_node01:
+          classes:
+          - cluster.mk22_lab_dvr.stacklight.proxy

--- a/classes/cluster/mk22_lab_dvr/fuel/config.yml
+++ b/classes/cluster/mk22_lab_dvr/fuel/config.yml
@@ -32,6 +32,7 @@ parameters:
     salt_master_host: 127.0.0.1
     salt_master_base_environment: dev
     salt_minion_ca_host: ${linux:network:fqdn}
+    salt_master_api_port: 8088
   linux:
     network:
       interface:

--- a/classes/cluster/mk22_lab_dvr/openstack/proxy.yml
+++ b/classes/cluster/mk22_lab_dvr/openstack/proxy.yml
@@ -13,3 +13,4 @@ parameters:
       authority: mk_lab_ca
       engine: salt
       mode: secure
+    salt_minion_ca_host: cfg01.${_param:cluster_domain}

--- a/classes/cluster/mk22_lab_dvr/openstack/proxy.yml
+++ b/classes/cluster/mk22_lab_dvr/openstack/proxy.yml
@@ -10,7 +10,7 @@ parameters:
     cluster_vip_address: ${_param:openstack_proxy_address}
     nginx_proxy_ssl:
       enabled: true
-      authority: mk_lab_ca
+      authority: ${_param:salt_minion_ca_authority}
       engine: salt
       mode: secure
     salt_minion_ca_host: cfg01.${_param:cluster_domain}

--- a/classes/cluster/mk22_lab_dvr/stacklight/proxy.yml
+++ b/classes/cluster/mk22_lab_dvr/stacklight/proxy.yml
@@ -9,6 +9,6 @@ parameters:
   _param:
     nginx_proxy_ssl:
       enabled: true
-      authority: mk_lab_ca
+      authority: ${_param:salt_minion_ca_authority}
       engine: salt
       mode: secure


### PR DESCRIPTION
This change is only for mk22_lab_basic, mk22_lab_dvr and
mk22_lab_advanced. Previously the proxy service was deployed on the
Salt master node but it didn't match with real-world deployments that
use dedicated proxy nodes.