### PR TITLE
Fix class for the Neutron control clusters

### DIFF
--- a/classes/cluster/mk22_lab_advanced/openstack/control.yml
+++ b/classes/cluster/mk22_lab_advanced/openstack/control.yml
@@ -12,7 +12,7 @@ classes:
 - system.glance.control.cluster
 - system.glance.control.storage.glusterfs
 - system.nova.control.cluster
-- system.neutron.control.cluster
+- system.neutron.control.opencontrail.cluster
 - system.cinder.control.cluster
 - system.heat.server.cluster
 - system.ceilometer.server.cluster

--- a/classes/cluster/mk22_lab_basic/openstack/control.yml
+++ b/classes/cluster/mk22_lab_basic/openstack/control.yml
@@ -12,7 +12,7 @@ classes:
 - system.glance.control.cluster
 - system.glance.control.storage.glusterfs
 - system.nova.control.cluster
-- system.neutron.control.cluster
+- system.neutron.control.opencontrail.cluster
 - system.cinder.control.cluster
 - system.heat.server.cluster
 - system.ceilometer.server.cluster


### PR DESCRIPTION
It is now required to use neutron.control.opencontrail.cluster class
when using OpenContrail instead of neutron.control.cluster.