### PR TITLE
Add configs for ElasticSearch Telemetry backend into models

### DIFF
--- a/classes/cluster/mk22_lab_advanced/init.yml
+++ b/classes/cluster/mk22_lab_advanced/init.yml
@@ -52,3 +52,4 @@ parameters:
     stacklight_monitor_node03_address: 172.16.10.109
 
     stacklight_telemetry_node01_address: ${_param:stacklight_monitor_node01_address}
+    stacklight_log_address: ${_param:stacklight_monitor_address}

--- a/classes/cluster/mk22_lab_basic/init.yml
+++ b/classes/cluster/mk22_lab_basic/init.yml
@@ -49,3 +49,4 @@ parameters:
     stacklight_monitor_address: 172.16.10.107
     stacklight_monitor_node01_address: 172.16.10.107
     stacklight_telemetry_node01_address: ${_param:stacklight_monitor_node01_address}
+    stacklight_log_address: ${_param:stacklight_monitor_address}


### PR DESCRIPTION
Reclass model needs configs for ElasticSearch backend with
different names. Right names are defined in this commit